### PR TITLE
Document stack: uv tool Python, CLI, email provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **zehut** — "Agents first secrets manager." A secrets manager whose primary clients are AI agents rather than humans. Repo: https://github.com/OriNachum/zehut
 
+## Stack
+
+- **Language/runtime:** Python, packaged as a **uv tool** (install via `uv tool install zehut`, run as a CLI).
+- **Interface:** CLI-first. The agent-facing API (however it ends up — library, local socket, HTTP) should be reachable through the CLI too.
+- **Delivery channel:** email provider. Zehut sends/receives via email — expect an email-based flow to be part of how secrets are issued, rotated, or verified. Pin down which provider and the exact flow before implementing.
+
 ## Current State
 
-Greenfield. The repo contains only `README.md`, `LICENSE` (MIT), and a Python `.gitignore`. There is no source code, build system, test suite, or CI configured yet. Before adding code, expand this file with:
+Greenfield. The repo contains only `README.md`, `LICENSE` (MIT), and a Python `.gitignore`. No `pyproject.toml`, source, tests, or CI yet. Still-open design questions before code lands:
 
-- Chosen language/toolchain and why (the `.gitignore` is Python-flavored but nothing is committed)
-- The agent-facing API shape (how agents authenticate, request secrets, and have access scoped — this is the core design question for an "agents first" secrets manager)
+- The agent-facing API shape (how agents authenticate, request secrets, and have access scoped — the core design question for an "agents first" secrets manager)
 - Storage/backend decisions (local file, cloud KMS, HSM, etc.)
 - Threat model — secrets managers live or die by this; write it down before the first secret is stored
+- Email provider choice and what email is actually used for in the flow
 
-## Conventions Inherited from the Workspace
+## Workflow
 
-This repo lives under `/home/spark/git/`, whose workspace-level `CLAUDE.md` assumes:
-
-- **uv** for Python dependency management (if Python is chosen)
-- Projects own their own version bumps and CHANGELOGs
-- Branch → implement → version bump → PR is the standard flow
-
-Nothing in this repo enforces those yet — they are defaults to follow unless a reason emerges to diverge.
+- **Branch + PR** for all changes by default. Direct pushes to `main` only with explicit per-change authorization.
+- Follow the workspace defaults from `/home/spark/git/CLAUDE.md`: `uv` for deps, per-project version bump before PR.


### PR DESCRIPTION
## Summary
- Records the first concrete tech decisions in CLAUDE.md: uv-tool-delivered Python, CLI-first, email provider as a delivery channel.
- Reframes remaining open design questions (API shape, storage, threat model, email flow specifics) as things still to decide.
- Pins branch + PR as the default workflow; direct pushes to main require explicit per-change approval.

## Test plan
- [x] CLAUDE.md renders and reads cleanly
- [ ] Revisit once `pyproject.toml` lands to confirm the uv-tool framing still matches reality

- Claude