### PR TITLE
feat: v1 scaffold — identity layer (closes greenfield)

### DIFF
--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: version-bump
+description: >
+  Bump the semver version in pyproject.toml (major, minor, or patch) and
+  prepend a Keep-a-Changelog entry to CHANGELOG.md. Use when preparing a
+  release, before creating a PR (the version-check CI job blocks merge if
+  you don't), or when the user says "bump version", "release", or
+  "increment version".
+---
+
+# Version Bump
+
+Bump the semver version in `pyproject.toml` and prepend a new entry to
+`CHANGELOG.md`. Mirrors the AgentCulture workflow used by `culture` and
+other org repos; imported here so the repo is self-contained.
+
+## Usage
+
+Run from the repo root.
+
+```bash
+# With changelog content (pipe JSON via stdin):
+echo '{"added":["New X"],"changed":["Refactored Y"],"fixed":["Bug in Z"]}' \
+  | python3 .claude/skills/version-bump/scripts/bump.py minor
+
+# Without changelog content (inserts empty ### Added/Changed/Fixed stubs):
+python3 .claude/skills/version-bump/scripts/bump.py patch
+
+# Check current version without bumping:
+python3 .claude/skills/version-bump/scripts/bump.py show
+```
+
+## Bump Types
+
+| Type    | Example        | When to use                                                       |
+|---------|----------------|-------------------------------------------------------------------|
+| `major` | 0.1.0 → 1.0.0  | Breaking changes, namespace restructures, CLI surface breaks      |
+| `minor` | 0.1.0 → 0.2.0  | New features, new commands, new modules                           |
+| `patch` | 0.1.0 → 0.1.1  | Bug fixes, doc updates, dependency bumps, CI-only changes         |
+| `show`  | prints `0.1.0` | Read-only — no files changed                                      |
+
+## Changelog JSON Format
+
+Pass via stdin. All fields are optional — only non-empty sections are rendered.
+
+```json
+{
+  "added":   ["List of new features"],
+  "changed": ["List of changes to existing functionality"],
+  "fixed":   ["List of bug fixes"]
+}
+```
+
+## What It Updates
+
+1. `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
+   the package `__init__.py` reads it via `importlib.metadata`, so there is no
+   separate `__version__` string to keep in sync).
+2. `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
+
+## Workflow
+
+When invoking this skill, the agent should:
+
+1. Determine the bump type from the staged/unstaged diff (patch for fixes,
+   minor for new features, major for breaking changes).
+2. Summarize the changes into `added` / `changed` / `fixed` lists.
+3. Pipe the JSON and run the script.
+4. Verify with `show`.
+5. Commit the bumped `pyproject.toml` + `CHANGELOG.md` alongside the code
+   changes, so the version-check CI job sees a consistent bump.
+
+## Why repo-local (not the user-global skill)
+
+A matching skill exists at `~/.claude/skills/version-bump/` for personal use,
+but committing it into this repo means:
+
+- The skill travels with the clone — CI hooks, other contributors, and
+  agents on fresh machines all discover it without personal configuration.
+- The `.md` paths in this SKILL.md reference the in-repo script, so the
+  guidance is accurate regardless of whether the user has the global skill.

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Bump the version in pyproject.toml, __init__.py, and CHANGELOG.md.
+
+Usage:
+    bump.py major    # 0.1.0 -> 1.0.0
+    bump.py minor    # 0.1.0 -> 0.2.0
+    bump.py patch    # 0.1.0 -> 0.1.1
+    bump.py show     # print current version
+
+Changelog entries are passed via stdin as a JSON object:
+    {
+      "added": ["New CLI command", "Observer module"],
+      "changed": ["Restructured namespace"],
+      "fixed": ["WHO reply index bug"]
+    }
+
+If no stdin is provided, an empty stub is inserted.
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def find_pyproject() -> Path:
+    """Walk up from cwd to find pyproject.toml."""
+    current = Path.cwd()
+    while current != current.parent:
+        candidate = current / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+    print("ERROR: pyproject.toml not found", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_version(path: Path) -> str:
+    """Extract version string from pyproject.toml."""
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: version field not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """Bump the specified part of a semver version."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"ERROR: version '{version}' is not semver (x.y.z)", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        print(f"ERROR: unknown bump type '{part}' (use major, minor, or patch)", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_version(path: Path, old: str, new: str) -> None:
+    """Replace old version with new in pyproject.toml."""
+    text = path.read_text()
+    updated = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    path.write_text(updated)
+
+
+def read_changelog_entries() -> dict:
+    """Read changelog entries from stdin as JSON."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print("WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr)
+        return {}
+
+
+def format_changelog_section(new: str, entries: dict) -> str:
+    """Format a changelog section from entries dict."""
+    today = date.today().isoformat()
+    lines = [f"## [{new}] - {today}\n"]
+
+    for section in ("added", "changed", "fixed"):
+        items = entries.get(section, [])
+        if items:
+            lines.append(f"\n### {section.capitalize()}\n")
+            for item in items:
+                lines.append(f"- {item}")
+            lines.append("")
+
+    # If no entries at all, add empty sections
+    if not any(entries.get(s) for s in ("added", "changed", "fixed")):
+        lines.append("\n### Added\n")
+        lines.append("\n### Changed\n")
+        lines.append("\n### Fixed\n")
+
+    return "\n".join(lines) + "\n"
+
+
+def update_changelog(project_root: Path, new: str, entries: dict) -> None:
+    """Insert a new changelog entry into CHANGELOG.md."""
+    changelog = project_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print("No CHANGELOG.md found — skipping")
+        return
+
+    text = changelog.read_text()
+    new_entry = format_changelog_section(new, entries)
+
+    marker = "## ["
+    idx = text.find(marker)
+    if idx > 0:
+        changelog.write_text(text[:idx] + new_entry + text[idx:])
+        print(f"Updated CHANGELOG.md with [{new}]")
+    else:
+        print("WARNING: could not find insertion point in CHANGELOG.md", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    part = sys.argv[1].lower()
+    path = find_pyproject()
+    current = read_version(path)
+
+    if part == "show":
+        print(current)
+        sys.exit(0)
+
+    # Read changelog entries before bumping
+    entries = read_changelog_entries()
+
+    new = bump(current, part)
+    write_version(path, current, new)
+
+    # Also update __init__.py if it has __version__
+    init_candidates = [
+        path.parent / path.parent.name / "__init__.py",
+    ]
+    for init in init_candidates:
+        if init.exists():
+            init_text = init.read_text()
+            if f'__version__ = "{current}"' in init_text:
+                init.write_text(init_text.replace(
+                    f'__version__ = "{current}"',
+                    f'__version__ = "{new}"',
+                ))
+                print(f"Updated {init.relative_to(path.parent)}")
+
+    # Update changelog
+    update_changelog(path.parent, new, entries)
+
+    print(f"{current} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist,.venv
+per-file-ignores =
+    tests/*:S101

--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,4 @@ extend-ignore = E203, W503
 exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
     tests/*:S101
+    tests/test_smoke.py:S101,S404,S603

--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,5 @@ exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
     tests/*:S101
     tests/test_smoke.py:S101,S404,S603
+    tests/unit/test_backend_system.py:S101,S404,S603
+    zehut/backend/system.py:S404,S603

--- a/.flake8
+++ b/.flake8
@@ -5,5 +5,6 @@ exclude = .git,__pycache__,build,dist,.venv
 per-file-ignores =
     tests/*:S101
     tests/test_smoke.py:S101,S404,S603
+    tests/test_self_verify.py:S101,S404,S603
     tests/unit/test_backend_system.py:S101,S404,S603
     zehut/backend/system.py:S404,S603

--- a/.github/workflows/Dockerfile.integration
+++ b/.github/workflows/Dockerfile.integration
@@ -8,7 +8,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --no-cache-dir uv
 
 WORKDIR /src
-COPY pyproject.toml uv.lock ./
+# README.md must be present for hatchling to validate the project metadata
+# during `uv sync` (pyproject.toml declares `readme = "README.md"`).
+COPY pyproject.toml uv.lock README.md ./
 COPY zehut ./zehut
 COPY tests ./tests
 COPY .flake8 ./

--- a/.github/workflows/Dockerfile.integration
+++ b/.github/workflows/Dockerfile.integration
@@ -1,11 +1,10 @@
 # Disposable image for running tests that require real useradd/userdel.
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        sudo passwd \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --no-cache-dir uv
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends sudo passwd \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir uv
 
 WORKDIR /src
 # README.md must be present for hatchling to validate the project metadata

--- a/.github/workflows/Dockerfile.integration
+++ b/.github/workflows/Dockerfile.integration
@@ -1,5 +1,19 @@
 # Disposable image for running tests that require real useradd/userdel.
+#
+# Root is INTENTIONAL. This image exists solely to run the integration
+# tests in tests/integration/, which exercise `useradd` and `userdel` and
+# therefore need root. The container is built per-CI-run, runs no user
+# code outside the pytest invocation, and is discarded after. See
+# docs/threat-model.md §risk-surfaces and issue #11 for the long-form
+# discussion + the rootless-refactor alternative.
+#
+# (SonarCloud hotspot docker:S6471 is marked REVIEWED/SAFE for this
+# image in the SonarCloud UI; see PR #2 comment history.)
 FROM python:3.12-slim
+
+# Make root explicit so intent is obvious in the Dockerfile, not only
+# inherited from the base image.
+USER root
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends sudo passwd \

--- a/.github/workflows/Dockerfile.integration
+++ b/.github/workflows/Dockerfile.integration
@@ -1,0 +1,19 @@
+# Disposable image for running tests that require real useradd/userdel.
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        sudo passwd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /src
+COPY pyproject.toml uv.lock ./
+COPY zehut ./zehut
+COPY tests ./tests
+COPY .flake8 ./
+
+RUN uv sync
+
+# Default runs unit + integration. Override at `docker run` time.
+CMD ["uv", "run", "pytest", "-v"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,12 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          # Make PR re-runs idempotent: once a version is uploaded to
+          # TestPyPI, subsequent attempts on the same version number
+          # would otherwise fail with 400. skip-existing turns that into
+          # a no-op. A real version bump is still enforced by tests.yml's
+          # version-check job for every PR.
+          skip-existing: true
 
   pypi:
     needs: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,23 +5,24 @@ on:
   push:
     branches: [main]
 
-permissions:
-  id-token: write  # for Trusted Publishing (OIDC)
-  contents: read
+# No workflow-level permissions — scoped per-job below per
+# SonarCloud S8233/S8264.
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.v.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync
       - run: uv build
       - id: v
         run: echo "version=$(grep -E '^version = ' pyproject.toml | head -1 | awk -F'"' '{print $2}')" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dist
           path: dist/
@@ -30,15 +31,18 @@ jobs:
     needs: build
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # for Trusted Publishing (OIDC)
+      contents: read
     environment:
       name: testpypi
       url: https://test.pypi.org/project/zehut/
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           # Make PR re-runs idempotent: once a version is uploaded to
@@ -52,12 +56,15 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # for Trusted Publishing (OIDC)
+      contents: read
     environment:
       name: pypi
       url: https://pypi.org/project/zehut/
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: dist
           path: dist/
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,57 @@
+name: publish
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write  # for Trusted Publishing (OIDC)
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv build
+      - id: v
+        run: echo "version=$(grep -E '^version = ' pyproject.toml | head -1 | awk -F'"' '{print $2}')" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  testpypi:
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/zehut/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pypi:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/zehut/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -23,8 +23,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
       - run: uv sync
-      - run: uv run pip install pip-audit
-      - run: uv run pip-audit
+      # `uvx` runs the tool in an isolated uv-managed environment. Avoids
+      # the non-uv `pip install` path that was flagged by Qodo.
+      - run: uvx pip-audit
 
   trivy-fs:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -12,16 +12,16 @@ jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync
       - run: uv run bandit -r zehut -c pyproject.toml
 
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync
       # `uvx` runs the tool in an isolated uv-managed environment. Avoids
       # the non-uv `pip install` path that was flagged by Qodo.
@@ -30,8 +30,8 @@ jobs:
   trivy-fs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # master
         with:
           scan-type: fs
           scan-ref: .

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -1,0 +1,37 @@
+name: security
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"  # weekly, Monday 05:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run bandit -r zehut -c pyproject.toml
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run pip install pip-audit
+      - run: uv run pip-audit
+
+  trivy-fs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,10 @@ jobs:
       - run: uv run isort --check-only zehut tests
       - run: uv run flake8 --config=.flake8 zehut tests
       - run: uv run bandit -r zehut -c pyproject.toml
+      - run: uv run pylint --errors-only zehut
+      - uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: '**/*.md'
 
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run black --check zehut tests
+      - run: uv run isort --check-only zehut tests
+      - run: uv run flake8 --config=.flake8 zehut tests
+      - run: uv run bandit -r zehut -c pyproject.toml
+
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run pytest -n auto --cov=zehut --cov-report=term -m "not integration"
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build integration image
+        run: docker build -t zehut-int -f .github/workflows/Dockerfile.integration .
+      - name: Run integration tests inside container
+        run: docker run --rm -e ZEHUT_DOCKER=1 zehut-int uv run pytest tests/integration -v -m integration
+
+  version-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Compare versions
+        run: |
+          set -euo pipefail
+          head_version=$(grep -E '^version = ' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+          git fetch origin main --depth=1
+          base_version=$(git show origin/main:pyproject.toml | grep -E '^version = ' | head -1 | awk -F'"' '{print $2}')
+          echo "base=$base_version head=$head_version"
+          if [ "$base_version" = "$head_version" ]; then
+            echo "ERROR: version unchanged. Run the version-bump skill." >&2
+            exit 1
+          fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,30 +12,30 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync
       - run: uv run black --check zehut tests
       - run: uv run isort --check-only zehut tests
       - run: uv run flake8 --config=.flake8 zehut tests
       - run: uv run bandit -r zehut -c pyproject.toml
       - run: uv run pylint --errors-only zehut
-      - uses: DavidAnson/markdownlint-cli2-action@v16
+      - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8  # v16
         with:
           globs: '**/*.md'
 
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
       - run: uv sync
       - run: uv run pytest -n auto --cov=zehut --cov-report=term -m "not integration"
 
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Build integration image
         run: docker build -t zehut-int -f .github/workflows/Dockerfile.integration .
       - name: Run integration tests inside container
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
       - name: Compare versions

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,9 +53,17 @@ jobs:
           set -euo pipefail
           head_version=$(grep -E '^version = ' pyproject.toml | head -1 | awk -F'"' '{print $2}')
           git fetch origin main --depth=1
-          base_version=$(git show origin/main:pyproject.toml | grep -E '^version = ' | head -1 | awk -F'"' '{print $2}')
+          # `git show origin/main:pyproject.toml` fails when main does not yet
+          # have pyproject.toml (first PR to introduce it). Treat that case as
+          # initial release — a bump isn't required.
+          if base_pyproject=$(git show origin/main:pyproject.toml 2>/dev/null); then
+            base_version=$(echo "$base_pyproject" | grep -E '^version = ' | head -1 | awk -F'"' '{print $2}')
+          else
+            base_version=""
+            echo "note: origin/main has no pyproject.toml; treating as initial release."
+          fi
           echo "base=$base_version head=$head_version"
-          if [ "$base_version" = "$head_version" ]; then
+          if [ -n "$base_version" ] && [ "$base_version" = "$head_version" ]; then
             echo "ERROR: version unchanged. Run the version-bump skill." >&2
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,13 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# zehut local
+/.venv/
+/dist/
+/build/
+/uv.lock.local
+/.coverage
+/htmlcov/
+/.pytest_cache/
+/.ruff_cache/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -11,3 +11,8 @@ ignores:
   - "**/node_modules/**"
   - "dist/**"
   - "build/**"
+  # Internal working documents (design specs + implementation plans). These
+  # carry tight nested task descriptions and code-block scaffolding that do
+  # not need strict MD031/MD032/MD040 compliance. They are not user-facing
+  # documentation.
+  - "docs/superpowers/**"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,13 @@
+config:
+  default: true
+  MD013: false  # line-length
+  MD060: false  # no-hr-after-heading (lint-cli2 plugin unused here)
+  MD033:        # allow inline HTML (for the occasional <br>)
+    allowed_elements: [br, details, summary]
+
+globs:
+  - "**/*.md"
+ignores:
+  - "**/node_modules/**"
+  - "dist/**"
+  - "build/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3.12
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bandit, flake8-bugbear]
+        args: ["--config=.flake8"]
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.13.0
+    hooks:
+      - id: markdownlint-cli2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to `zehut` will be documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- Initial v1 release: `zehut init`, `zehut user create/list/show/set/delete/switch/whoami/current`,
+  `zehut configuration show/set/set-domain`, `zehut doctor`, `zehut learn`,
+  `zehut overview`, `zehut explain`.
+- System-backed and logical identity backings.
+- Deterministic email generation from a configurable pattern +
+  collision suffixing.
+- Ambient identity resolution (OS user → registry match →
+  `$ZEHUT_IDENTITY` fallback).
+- Root-owned machine state under `/etc/zehut/` and `/var/lib/zehut/`,
+  with `fcntl` locking and atomic rename.
+- Zero runtime dependencies (stdlib only).
+- CI: lint, unit tests, Docker-gated integration tests, Trusted
+  Publishing to TestPyPI (on PR) and PyPI (on push to `main`).
+
+[Unreleased]: https://github.com/OriNachum/zehut/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/OriNachum/zehut/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,43 @@ Greenfield. The repo contains only `README.md`, `LICENSE` (MIT), and a Python `.
 
 - **Branch + PR** for all changes by default. Direct pushes to `main` only with explicit per-change authorization.
 - Follow the workspace defaults from `/home/spark/git/CLAUDE.md`: `uv` for deps, per-project version bump before PR.
+
+## Implementation status (post-v1)
+
+Implemented surface lives in `zehut/`:
+
+- CLI entry: `zehut/cli/__init__.py` (argparse, dispatch, `--json`, error routing).
+- Commands: `zehut/cli/_commands/{init,configuration,user,doctor,learn,overview,explain}.py`.
+- Core modules: `zehut/{fs,config,privilege,users}.py`.
+- Backends: `zehut/backend/{base,logical,system}.py`.
+
+State on disk:
+
+- `/etc/zehut/config.toml` (root-owned, 0o644).
+- `/var/lib/zehut/users.json` (root-owned, 0o644) — stable API consumed
+  by a separate (forthcoming) secrets CLI.
+
+Test-only env hooks (see `docs/testing.md`): `ZEHUT_CONFIG_DIR`,
+`ZEHUT_STATE_DIR`, `ZEHUT_ASSUME_ROOT`, `ZEHUT_DOCKER`.
+
+## Version bumps
+
+Every PR MUST bump the version. Run:
+
+```bash
+python3 .claude/skills/version-bump/scripts/bump.py {patch|minor|major}
+```
+
+Patch for docs/config/CI; minor for new commands or verbs; major for
+breaking changes (schema_version bump, removed verbs, exit-code
+reshuffle). The `version-check` job in `tests.yml` enforces this on PR.
+
+## Reference
+
+- Design spec: `docs/superpowers/specs/2026-04-24-zehut-cli-design.md`.
+- Implementation plan: `docs/superpowers/plans/2026-04-24-zehut-cli-v1.md`.
+- Threat model: `docs/threat-model.md`.
+- Identity model: `docs/identity-model.md`.
+- Testing notes: `docs/testing.md`.
+- Patterned on: `../afi-cli` (same CI, error-routing, and versioning
+  conventions).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-**zehut** — "Agents first secrets manager." A secrets manager whose primary clients are AI agents rather than humans. Repo: https://github.com/OriNachum/zehut
+**zehut** — "Agents first secrets manager." A secrets manager whose primary clients are AI agents rather than humans. Repo: <https://github.com/OriNachum/zehut>.
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
 # zehut
-Agents first secrets manager
+
+Agents-first identity layer for Linux hosts.
+
+`zehut` provisions and tracks machine-local identities — either **system-backed**
+(real OS users via `useradd`) or **logical** (metadata only) — and gives each
+one a deterministic email address from a configured domain. A separate CLI
+consumes zehut's `users.json` registry to provide secrets management on top of
+this identity foundation.
+
+## Install
+
+```bash
+uv tool install zehut
+```
+
+## Quick start
+
+```bash
+# One-time bootstrap (needs sudo).
+sudo $(which zehut) init --domain agents.example.com --default-backend system
+
+# Create a system-backed user.
+sudo $(which zehut) user create alice --nick Ali --about "QA agent"
+
+# Create a logical (metadata-only) user.
+zehut user create bot --logical
+
+# List, show, switch.
+zehut user list
+zehut user show alice
+zehut user switch alice     # system: exec sudo -u alice -i
+eval "$(zehut user switch bot)"  # logical: sets ZEHUT_IDENTITY
+
+# Health check.
+zehut doctor
+```
+
+## Documentation
+
+- [Identity model](docs/identity-model.md)
+- [Threat model](docs/threat-model.md)
+- [Testing](docs/testing.md)
+- [Design spec](docs/superpowers/specs/2026-04-24-zehut-cli-design.md)
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/docs/identity-model.md
+++ b/docs/identity-model.md
@@ -1,0 +1,61 @@
+# zehut identity model
+
+A zehut identity ("user" in v1) is:
+
+- a stable **ULID `id`** — immutable, safe to reference in audit trails
+  and future rename operations.
+- a **`name`** — the primary handle users type. For system-backed users
+  this MUST equal the OS username.
+- optional **`nick`** and **`about`** metadata.
+- an auto-generated **`email`** derived from `configuration.email_pattern`
+  and `configuration.domain` at create-time, collision-suffixed if needed.
+  Immutable post-create in v1.
+- a **backing**: `system` or `logical`.
+
+## Backings
+
+### System-backed
+
+- A real local OS account (`useradd` at create, `userdel` at delete).
+- Home directory created by default (`useradd -m`); skipped deletion
+  with `zehut user delete --keep-home`.
+- Primary group matches the username (`useradd -U`).
+- Default shell `/bin/bash`.
+- Provisioning requires root — the CLI surfaces a `sudo zehut …`
+  remediation when called unprivileged.
+
+### Logical
+
+- Metadata only. No OS account. No sudo required for create/delete.
+- "Current identity" cannot be resolved ambient-style (no OS user to
+  match against); falls back to `$ZEHUT_IDENTITY` env var.
+- Useful when you need a zehut identity for accounting or email
+  allocation but don't want an OS account to manage.
+
+## Ambient resolution
+
+`zehut user whoami` (aliased `current`), and the optional `<name>`
+argument of `zehut user show` / `set`, resolve the current identity in
+this order:
+
+1. **OS user match**: `pwd.getpwuid(os.geteuid()).pw_name` is looked up
+   against system-backed registry entries. If found, that is the
+   identity. Zero-config for agents launched under a zehut-provisioned
+   user (Claude Agent SDK, cron, systemd services, `sudo -u …`).
+2. **`$ZEHUT_IDENTITY`**: set by `eval $(zehut user switch <logical>)`
+   inside a shell, or exported manually.
+3. **None**: commands that require a current identity exit with
+   `EXIT_USER_ERROR` and a remediation hint.
+
+## The registry as a stable contract
+
+`/var/lib/zehut/users.json` is consumed by a separate (forthcoming)
+secrets CLI. Its `schema_version = 1` shape is stable; any breaking
+change bumps the version and ships a `zehut migrate` verb.
+
+Downstream consumers should:
+
+- Read the file under `fs.shared_lock(/var/lib/zehut/.lock)`.
+- Never write. All mutations MUST go through `zehut user …` /
+  `zehut configuration …` so the system-layer provisioning stays in
+  sync.

--- a/docs/superpowers/plans/2026-04-24-zehut-cli-v1.md
+++ b/docs/superpowers/plans/2026-04-24-zehut-cli-v1.md
@@ -1,0 +1,5479 @@
+# zehut CLI v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `zehut` 0.1.0 to PyPI/TestPyPI — an agent-first CLI that manages local machine identities (system-backed via `useradd` + logical metadata-only), provisioned under `/etc/zehut/` + `/var/lib/zehut/`, consumed by a separate secrets CLI via a stable `users.json` contract.
+
+**Architecture:** Single Python package, zero runtime dependencies (stdlib only). argparse noun-verb CLI mirroring `../afi-cli` conventions. Registry on disk (JSON + fcntl locks, atomic rename). Backend strategy pattern (`system` shells to `useradd`/`userdel`; `logical` is metadata-only). Ambient identity resolution from `os.geteuid()` → `pwd.getpwuid` → registry lookup, with `$ZEHUT_IDENTITY` env-var fallback for logical users.
+
+**Tech Stack:** Python 3.12+, uv, hatchling, argparse, fcntl, tomllib, pytest + pytest-xdist + pytest-cov, black, isort, flake8 (+ bandit/bugbear), pylint, GitHub Actions with OIDC Trusted Publishing.
+
+**Reference repo:** `/home/spark/git/afi-cli` — the project this one mirrors. When a task says "pattern from afi-cli", open that path to cross-check. You do NOT need to read afi-cli to execute this plan — every piece of code you need is inline below — but it's the reference of record for style.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-zehut-cli-design.md` in this repo. Keep it open while working.
+
+**Branching:** You are already on `docs/zehut-cli-v1-spec` (where the spec lives). Create a fresh branch `feat/v1-scaffold` off that for implementation. Every task below ends in a commit. Do not push to `main` — PRs only.
+
+---
+
+## Conventions used throughout this plan
+
+- **Paths are absolute from the repo root** (`/home/spark/git/zehut/…`) unless shown relatively inside a code block.
+- **Commit messages** use Conventional Commits (`feat:`, `test:`, `chore:`, `docs:`, `ci:`) because the CHANGELOG generator in `afi-cli`'s version-bump skill parses them.
+- **`version-bump`**: you do NOT bump the version in the commits below because that skill is vendored in Task 17. Until then, keep `version = "0.1.0"` in `pyproject.toml`. The PR that merges this whole stack will be the one bumping to `0.1.0` as its first published release — no bump-per-commit during initial scaffolding.
+- **Every test file imports from `zehut.*`**. Never relative imports in tests.
+- **Every module gets a one-paragraph module docstring** stating its responsibility (see examples in afi-cli). No TODOs in docstrings.
+- **Type hints everywhere** (`from __future__ import annotations` at top of every module; stdlib types only — no `typing.List`, use `list[str]`).
+- **Black line length: 100.** Matches `[tool.black]` config from Task 1.
+
+---
+
+## Task 1: Project skeleton — `pyproject.toml`, package dirs, basic CLI entry
+
+**Goal:** `uv sync` produces a working dev environment, `uv run zehut --version` prints a version, `uv run pytest` discovers an empty test tree without errors.
+
+**Files:**
+- Create: `/home/spark/git/zehut/pyproject.toml`
+- Create: `/home/spark/git/zehut/.gitignore` (extend existing; the repo's Python `.gitignore` already covers most cases)
+- Create: `/home/spark/git/zehut/.flake8`
+- Create: `/home/spark/git/zehut/zehut/__init__.py`
+- Create: `/home/spark/git/zehut/zehut/__main__.py`
+- Create: `/home/spark/git/zehut/zehut/cli/__init__.py`
+- Create: `/home/spark/git/zehut/tests/__init__.py`
+- Create: `/home/spark/git/zehut/tests/unit/__init__.py`
+- Create: `/home/spark/git/zehut/tests/integration/__init__.py`
+- Create: `/home/spark/git/zehut/tests/test_smoke.py`
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /home/spark/git/zehut
+git checkout -b feat/v1-scaffold
+```
+
+- [ ] **Step 2: Write `pyproject.toml`**
+
+Path: `/home/spark/git/zehut/pyproject.toml`
+
+```toml
+[project]
+name = "zehut"
+version = "0.1.0"
+description = "Agents-first identity layer — local system & logical user registry with email assignment."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [{name = "Ori Nachum"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: System :: Systems Administration :: Authentication/Directory",
+    "Intended Audience :: System Administrators",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/OriNachum/zehut"
+Issues = "https://github.com/OriNachum/zehut/issues"
+
+[project.scripts]
+zehut = "zehut.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["zehut"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.0",
+    "pytest-cov>=4.1",
+    "bandit>=1.7.5",
+    "pylint>=2.17.0",
+    "flake8>=6.1",
+    "flake8-bandit>=4.1.1",
+    "flake8-bugbear>=23.7.10",
+    "coverage>=7.2.0",
+    "pre-commit>=3.5.0",
+    "isort>=5.12.0",
+    "black>=23.7.0",
+]
+
+[tool.coverage.run]
+source = ["zehut"]
+omit = ["zehut/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+known_first_party = ["zehut"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+markers = [
+    "integration: tests that shell out to real useradd/userdel (gated on root or ZEHUT_DOCKER=1)",
+]
+```
+
+- [ ] **Step 3: Write `.flake8`**
+
+Path: `/home/spark/git/zehut/.flake8`
+
+```ini
+[flake8]
+max-line-length = 100
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist,.venv
+per-file-ignores =
+    tests/*:S101
+```
+
+- [ ] **Step 4: Extend `.gitignore`**
+
+Append to `/home/spark/git/zehut/.gitignore`:
+
+```text
+
+# zehut local
+/.venv/
+/dist/
+/build/
+/uv.lock.local
+/.coverage
+/htmlcov/
+/.pytest_cache/
+/.ruff_cache/
+```
+
+- [ ] **Step 5: Create package files**
+
+Path: `/home/spark/git/zehut/zehut/__init__.py`
+
+```python
+"""zehut — agents-first identity layer.
+
+Exposes the package version via importlib.metadata so pyproject.toml is the
+single source of truth. No other top-level re-exports; callers import from
+submodules directly (`from zehut.users import Registry`, etc.).
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("zehut")
+except PackageNotFoundError:  # pragma: no cover — only hit in uninstalled dev trees
+    __version__ = "0.0.0+local"
+
+__all__ = ["__version__"]
+```
+
+Path: `/home/spark/git/zehut/zehut/__main__.py`
+
+```python
+"""Allow ``python -m zehut`` to reach the CLI entry point."""
+
+from __future__ import annotations
+
+import sys
+
+from zehut.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py`
+
+```python
+"""CLI entry point — Task 1 placeholder.
+
+This module is fleshed out in Task 6 (parser + dispatch + error routing).
+For now it exists so ``uv run zehut --version`` and ``python -m zehut`` work.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from zehut import __version__
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if args == ["--version"]:
+        print(f"zehut {__version__}")
+        return 0
+    # Placeholder: anything else prints a stub message.
+    print("zehut CLI not yet implemented — see docs/superpowers/plans/", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 6: Create test tree**
+
+Path: `/home/spark/git/zehut/tests/__init__.py` — empty file.
+
+Path: `/home/spark/git/zehut/tests/unit/__init__.py` — empty file.
+
+Path: `/home/spark/git/zehut/tests/integration/__init__.py` — empty file.
+
+Path: `/home/spark/git/zehut/tests/test_smoke.py`
+
+```python
+"""Smoke tests — prove the package is importable and --version works."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import zehut
+
+
+def test_version_attribute_exists() -> None:
+    assert isinstance(zehut.__version__, str)
+    assert zehut.__version__  # non-empty
+
+
+def test_cli_version_flag(tmp_path) -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "zehut", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "zehut" in result.stdout
+```
+
+- [ ] **Step 7: Install deps and run tests**
+
+```bash
+cd /home/spark/git/zehut
+uv sync
+uv run pytest tests/test_smoke.py -v
+```
+
+Expected: two tests pass. `uv.lock` is generated.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add pyproject.toml uv.lock .gitignore .flake8 zehut tests
+git commit -m "$(cat <<'EOF'
+feat: bootstrap package skeleton and CLI entry
+
+- pyproject.toml with hatchling build, zero runtime deps, dev group
+  mirroring afi-cli (pytest+xdist+cov, black, isort, flake8 family, bandit,
+  pylint, pre-commit)
+- zehut/__init__.py exposes __version__ via importlib.metadata
+- zehut/__main__.py + placeholder zehut/cli/__init__.py so python -m zehut
+  and `zehut --version` work end-to-end
+- Smoke test asserts the package imports and CLI --version exits 0
+EOF
+)"
+```
+
+---
+
+## Task 2: `zehut.fs` — paths, env overrides, atomic write, fcntl locking
+
+**Goal:** One module owns every filesystem concern: where things live, how we lock, how we write atomically. Everything else delegates here.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/fs.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_fs.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_fs.py`
+
+```python
+"""Unit tests for zehut.fs — paths, locking, atomic writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from zehut import fs
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    return config_dir, state_dir
+
+
+def test_default_paths_without_env(monkeypatch):
+    monkeypatch.delenv("ZEHUT_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("ZEHUT_STATE_DIR", raising=False)
+    assert fs.config_dir() == Path("/etc/zehut")
+    assert fs.state_dir() == Path("/var/lib/zehut")
+    assert fs.config_file() == Path("/etc/zehut/config.toml")
+    assert fs.users_file() == Path("/var/lib/zehut/users.json")
+    assert fs.lock_file() == Path("/var/lib/zehut/.lock")
+
+
+def test_paths_honour_env_overrides(tmp_zehut):
+    config_dir, state_dir = tmp_zehut
+    assert fs.config_dir() == config_dir
+    assert fs.state_dir() == state_dir
+    assert fs.config_file() == config_dir / "config.toml"
+    assert fs.users_file() == state_dir / "users.json"
+
+
+def test_atomic_write_text_creates_file_with_content(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+    fs.atomic_write_text(target, "hello\n", mode=0o644)
+    assert target.read_text() == "hello\n"
+    assert oct(target.stat().st_mode & 0o777) == oct(0o644)
+
+
+def test_atomic_write_text_overwrites(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+    target.write_text("old")
+    fs.atomic_write_text(target, "new", mode=0o644)
+    assert target.read_text() == "new"
+
+
+def test_atomic_write_text_leaves_no_tmp_on_success(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+    fs.atomic_write_text(target, "ok", mode=0o644)
+    tmps = [p for p in state_dir.iterdir() if p.name.startswith(".x.txt.")]
+    assert tmps == []
+
+
+def test_exclusive_lock_blocks_concurrent_writer(tmp_zehut):
+    _, state_dir = tmp_zehut
+    lock_path = state_dir / ".lock"
+    lock_path.touch()
+    observed: list[str] = []
+
+    def worker(tag: str, hold_for: float):
+        import time
+        with fs.exclusive_lock(lock_path):
+            observed.append(f"{tag}-enter")
+            time.sleep(hold_for)
+            observed.append(f"{tag}-leave")
+
+    t1 = threading.Thread(target=worker, args=("a", 0.2))
+    t2 = threading.Thread(target=worker, args=("b", 0.0))
+    t1.start()
+    # give t1 time to acquire the lock before t2 races
+    import time as _time
+    _time.sleep(0.05)
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # a must fully enter and leave before b enters
+    assert observed == ["a-enter", "a-leave", "b-enter", "b-leave"]
+
+
+def test_read_json_roundtrip(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "data.json"
+    payload = {"schema_version": 1, "users": []}
+    fs.atomic_write_text(target, json.dumps(payload), mode=0o644)
+    assert fs.read_json(target) == payload
+
+
+def test_read_json_missing_raises_filenotfound(tmp_zehut):
+    _, state_dir = tmp_zehut
+    with pytest.raises(FileNotFoundError):
+        fs.read_json(state_dir / "nope.json")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_fs.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'zehut.fs'` (or ImportError).
+
+- [ ] **Step 3: Implement `zehut/fs.py`**
+
+Path: `/home/spark/git/zehut/zehut/fs.py`
+
+```python
+"""Filesystem primitives: path resolution, locking, atomic writes.
+
+Every other module delegates to this one for anything touching disk. The
+env overrides ``ZEHUT_CONFIG_DIR`` and ``ZEHUT_STATE_DIR`` exist for tests
+and are not a user-facing feature (see docs/testing.md).
+
+Locking: ``exclusive_lock`` and ``shared_lock`` are thin ``fcntl.flock``
+context managers over ``/var/lib/zehut/.lock``. Advisory only — nothing
+outside zehut participates — but enough to serialise zehut's own writers
+against readers on a single host.
+
+Atomic writes: write to a temp sibling, fsync, then ``os.replace``. On
+POSIX this is atomic w.r.t. crashes; readers see either the old file or
+the new one, never a half-written blob.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import json
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+_DEFAULT_CONFIG_DIR = Path("/etc/zehut")
+_DEFAULT_STATE_DIR = Path("/var/lib/zehut")
+
+
+def config_dir() -> Path:
+    return Path(os.environ.get("ZEHUT_CONFIG_DIR", str(_DEFAULT_CONFIG_DIR)))
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("ZEHUT_STATE_DIR", str(_DEFAULT_STATE_DIR)))
+
+
+def config_file() -> Path:
+    return config_dir() / "config.toml"
+
+
+def users_file() -> Path:
+    return state_dir() / "users.json"
+
+
+def lock_file() -> Path:
+    return state_dir() / ".lock"
+
+
+def atomic_write_text(target: Path, data: str, *, mode: int) -> None:
+    """Write ``data`` to ``target`` atomically, creating parents if needed."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def read_json(target: Path) -> Any:
+    with target.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@contextmanager
+def _locked(path: Path, op: int) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Open O_RDWR so both LOCK_SH and LOCK_EX work on the same fd.
+    flags = os.O_RDWR | os.O_CREAT
+    fd = os.open(str(path), flags, 0o644)
+    try:
+        fcntl.flock(fd, op)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        try:
+            os.close(fd)
+        except OSError as err:
+            if err.errno != errno.EBADF:
+                raise
+
+
+@contextmanager
+def exclusive_lock(path: Path) -> Iterator[None]:
+    """Hold ``LOCK_EX`` on ``path`` for the duration of the context."""
+    with _locked(path, fcntl.LOCK_EX):
+        yield
+
+
+@contextmanager
+def shared_lock(path: Path) -> Iterator[None]:
+    """Hold ``LOCK_SH`` on ``path`` for the duration of the context."""
+    with _locked(path, fcntl.LOCK_SH):
+        yield
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_fs.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests
+uv run isort zehut tests
+uv run flake8 --config=.flake8 zehut tests
+```
+
+Expected: black + isort produce no changes (or make them; re-run to see clean output); flake8 prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add zehut/fs.py tests/unit/test_fs.py
+git commit -m "feat(fs): paths, env overrides, atomic write, fcntl locking"
+```
+
+---
+
+## Task 3: `zehut.privilege` — root check and sudo-command advice
+
+**Goal:** One place to ask "am I root?" and "what's the sudo command I should print?". Every handler that needs root calls `require_root(…)` and gets a pre-built remediation string for free.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/privilege.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_privilege.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_privilege.py`
+
+```python
+"""Unit tests for zehut.privilege."""
+
+from __future__ import annotations
+
+import pytest
+
+from zehut import privilege
+
+
+def test_is_root_true(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 0)
+    assert privilege.is_root() is True
+
+
+def test_is_root_false(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 1000)
+    assert privilege.is_root() is False
+
+
+def test_require_root_passes_when_root(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 0)
+    # Should not raise
+    privilege.require_root(action="do a thing")
+
+
+def test_require_root_raises_when_not_root(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(privilege, "_zehut_binary", lambda: "/home/x/.local/bin/zehut")
+    with pytest.raises(privilege.PrivilegeError) as exc:
+        privilege.require_root(action="create a system user", argv=["user", "create", "alice", "--system"])
+    assert "sudo" in exc.value.remediation
+    assert "/home/x/.local/bin/zehut" in exc.value.remediation
+    assert "user create alice --system" in exc.value.remediation
+
+
+def test_sudo_command_uses_full_path(monkeypatch):
+    monkeypatch.setattr(privilege, "_zehut_binary", lambda: "/opt/zehut/bin/zehut")
+    cmd = privilege.sudo_command(["user", "create", "alice"])
+    assert cmd == "sudo /opt/zehut/bin/zehut user create alice"
+
+
+def test_sudo_command_falls_back_to_zehut_when_not_found(monkeypatch):
+    monkeypatch.setattr(privilege, "_zehut_binary", lambda: None)
+    cmd = privilege.sudo_command(["doctor"])
+    assert cmd == "sudo zehut doctor"
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_privilege.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'zehut.privilege'`.
+
+- [ ] **Step 3: Implement `zehut/privilege.py`**
+
+Path: `/home/spark/git/zehut/zehut/privilege.py`
+
+```python
+"""Privilege detection and sudo-advice construction.
+
+Every handler that mutates system state calls :func:`require_root` with a
+short ``action`` string and the raw argv of the offending command. On
+failure this module raises :class:`PrivilegeError` carrying a ready-to-copy
+remediation (``sudo /abs/path/zehut …``) — we resolve the absolute path
+because ``uv tool install`` places the binary in ``~/.local/bin`` which is
+not on root's ``secure_path`` under typical sudoers configs.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class PrivilegeError(Exception):
+    message: str
+    remediation: str
+
+    def __str__(self) -> str:  # pragma: no cover — trivial
+        return self.message
+
+
+def is_root() -> bool:
+    return os.geteuid() == 0
+
+
+def _zehut_binary() -> str | None:
+    """Return the absolute path to the running zehut binary, if known."""
+    # sys.argv[0] is reliable when invoked as an entry-point script.
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0 and os.path.isabs(argv0) and os.path.exists(argv0):
+        return argv0
+    # Fall back to shutil.which.
+    found = shutil.which("zehut")
+    return found if found else None
+
+
+def sudo_command(argv: list[str]) -> str:
+    binary = _zehut_binary() or "zehut"
+    return " ".join(["sudo", binary, *argv])
+
+
+def require_root(*, action: str, argv: list[str] | None = None) -> None:
+    if is_root():
+        return
+    argv = argv or []
+    remediation = f"re-run with: {sudo_command(argv)}"
+    raise PrivilegeError(
+        message=f"root privileges required to {action}",
+        remediation=remediation,
+    )
+```
+
+- [ ] **Step 4: Run tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_privilege.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+```
+
+Expected: no output from flake8.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add zehut/privilege.py tests/unit/test_privilege.py
+git commit -m "feat(privilege): root check + sudo-command remediation builder"
+```
+
+---
+
+## Task 4: `zehut.config` — load, save, validate, defaults
+
+**Goal:** One module owns the `config.toml` schema: reading it, writing it, validating it, and reporting structured errors when it's malformed or uninitialized.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/config.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_config.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_config.py`
+
+```python
+"""Unit tests for zehut.config."""
+
+from __future__ import annotations
+
+import pytest
+
+from zehut import config, fs
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    return config_dir, state_dir
+
+
+def test_default_config_values():
+    cfg = config.Config.default(domain="agents.example.com", backend="system")
+    assert cfg.schema_version == 1
+    assert cfg.domain == "agents.example.com"
+    assert cfg.default_backend == "system"
+    assert cfg.email_pattern == "{name}"
+    assert cfg.email_collision == "suffix"
+
+
+def test_save_and_load_roundtrip(tmp_zehut):
+    cfg = config.Config.default(domain="x.example.com", backend="logical")
+    config.save(cfg)
+    loaded = config.load()
+    assert loaded == cfg
+
+
+def test_save_writes_expected_toml(tmp_zehut):
+    config_dir, _ = tmp_zehut
+    cfg = config.Config.default(domain="agents.example.com", backend="system")
+    config.save(cfg)
+    text = (config_dir / "config.toml").read_text()
+    assert "schema_version = 1" in text
+    assert 'domain = "agents.example.com"' in text
+    assert 'backend = "system"' in text
+
+
+def test_load_missing_raises_state_error(tmp_zehut):
+    with pytest.raises(config.ConfigStateError) as exc:
+        config.load()
+    assert "not initialized" in str(exc.value).lower() or "missing" in str(exc.value).lower()
+
+
+def test_load_wrong_schema_version_raises(tmp_zehut):
+    config_dir, _ = tmp_zehut
+    (config_dir / "config.toml").write_text(
+        'schema_version = 2\n'
+        '[defaults]\nbackend = "system"\n'
+        '[email]\ndomain = "x.example.com"\npattern = "{name}"\ncollision = "suffix"\n'
+    )
+    with pytest.raises(config.ConfigStateError) as exc:
+        config.load()
+    assert "schema" in str(exc.value).lower()
+
+
+def test_load_rejects_unknown_backend(tmp_zehut):
+    config_dir, _ = tmp_zehut
+    (config_dir / "config.toml").write_text(
+        'schema_version = 1\n'
+        '[defaults]\nbackend = "wat"\n'
+        '[email]\ndomain = "x.example.com"\npattern = "{name}"\ncollision = "suffix"\n'
+    )
+    with pytest.raises(config.ConfigStateError):
+        config.load()
+
+
+def test_set_key_updates_value(tmp_zehut):
+    cfg = config.Config.default(domain="x.example.com", backend="system")
+    config.save(cfg)
+    config.set_key("domain", "agents.new.com")
+    reloaded = config.load()
+    assert reloaded.domain == "agents.new.com"
+
+
+def test_set_key_rejects_unknown_key(tmp_zehut):
+    cfg = config.Config.default(domain="x.example.com", backend="system")
+    config.save(cfg)
+    with pytest.raises(config.ConfigStateError):
+        config.set_key("not_a_real_key", "whatever")
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_config.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'zehut.config'`.
+
+- [ ] **Step 3: Implement `zehut/config.py`**
+
+Path: `/home/spark/git/zehut/zehut/config.py`
+
+```python
+"""Configuration file (``/etc/zehut/config.toml``) — load, save, validate.
+
+The on-disk format is stable as ``schema_version = 1``. Parsing uses
+``tomllib`` (stdlib, read-only); writing is hand-rolled because the
+serialiser in ``tomllib`` doesn't exist and pulling in ``tomli-w`` would
+add a runtime dependency for ~30 lines of work.
+
+This module never touches the users registry; that is ``zehut.users``'s
+job. Cross-file consistency checks live in ``zehut.cli._commands.doctor``.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, replace
+from typing import Literal
+
+from zehut import fs
+
+Backend = Literal["system", "logical"]
+CollisionMode = Literal["suffix"]
+
+_SCHEMA_VERSION = 1
+_VALID_BACKENDS: tuple[Backend, ...] = ("system", "logical")
+_VALID_COLLISION: tuple[CollisionMode, ...] = ("suffix",)
+_SETTABLE_KEYS = frozenset({"domain", "default_backend", "email_pattern", "email_collision"})
+
+
+class ConfigStateError(Exception):
+    """Raised for any config problem routable to EXIT_STATE (65)."""
+
+
+@dataclass(frozen=True)
+class Config:
+    schema_version: int
+    domain: str
+    default_backend: Backend
+    email_pattern: str
+    email_collision: CollisionMode
+
+    @classmethod
+    def default(cls, *, domain: str, backend: Backend) -> "Config":
+        if backend not in _VALID_BACKENDS:
+            raise ConfigStateError(f"invalid backend {backend!r}")
+        return cls(
+            schema_version=_SCHEMA_VERSION,
+            domain=domain,
+            default_backend=backend,
+            email_pattern="{name}",
+            email_collision="suffix",
+        )
+
+
+def _serialise(cfg: Config) -> str:
+    return (
+        f"schema_version = {cfg.schema_version}\n"
+        "\n"
+        "[defaults]\n"
+        f'backend = "{cfg.default_backend}"\n'
+        "\n"
+        "[email]\n"
+        f'domain = "{cfg.domain}"\n'
+        f'pattern = "{cfg.email_pattern}"\n'
+        f'collision = "{cfg.email_collision}"\n'
+    )
+
+
+def save(cfg: Config) -> None:
+    fs.atomic_write_text(fs.config_file(), _serialise(cfg), mode=0o644)
+
+
+def load() -> Config:
+    path = fs.config_file()
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as err:
+        raise ConfigStateError(
+            f"zehut is not initialized: {path} is missing"
+        ) from err
+    try:
+        doc = tomllib.loads(raw.decode("utf-8"))
+    except tomllib.TOMLDecodeError as err:
+        raise ConfigStateError(f"invalid TOML in {path}: {err}") from err
+
+    schema = doc.get("schema_version")
+    if schema != _SCHEMA_VERSION:
+        raise ConfigStateError(
+            f"unsupported schema_version {schema!r} in {path}; expected {_SCHEMA_VERSION}"
+        )
+    defaults = doc.get("defaults", {})
+    email = doc.get("email", {})
+    backend = defaults.get("backend")
+    if backend not in _VALID_BACKENDS:
+        raise ConfigStateError(
+            f"invalid [defaults].backend {backend!r}; expected one of {list(_VALID_BACKENDS)}"
+        )
+    domain = email.get("domain")
+    if not isinstance(domain, str) or not domain:
+        raise ConfigStateError(f"missing or empty [email].domain in {path}")
+    pattern = email.get("pattern", "{name}")
+    collision = email.get("collision", "suffix")
+    if collision not in _VALID_COLLISION:
+        raise ConfigStateError(
+            f"invalid [email].collision {collision!r}; expected one of {list(_VALID_COLLISION)}"
+        )
+    return Config(
+        schema_version=_SCHEMA_VERSION,
+        domain=domain,
+        default_backend=backend,
+        email_pattern=pattern,
+        email_collision=collision,
+    )
+
+
+def set_key(key: str, value: str) -> None:
+    """Mutate a single top-level config field and persist.
+
+    ``key`` is one of :data:`_SETTABLE_KEYS`. ``value`` is always accepted
+    as a string; type coercion/validation happens inside :func:`load` on
+    the next read.
+    """
+    if key not in _SETTABLE_KEYS:
+        raise ConfigStateError(
+            f"unknown config key {key!r}; settable keys: {sorted(_SETTABLE_KEYS)}"
+        )
+    cfg = load()
+    if key == "domain":
+        updated = replace(cfg, domain=value)
+    elif key == "default_backend":
+        if value not in _VALID_BACKENDS:
+            raise ConfigStateError(
+                f"invalid default_backend {value!r}; expected one of {list(_VALID_BACKENDS)}"
+            )
+        updated = replace(cfg, default_backend=value)  # type: ignore[arg-type]
+    elif key == "email_pattern":
+        updated = replace(cfg, email_pattern=value)
+    else:  # email_collision
+        if value not in _VALID_COLLISION:
+            raise ConfigStateError(
+                f"invalid email_collision {value!r}; expected one of {list(_VALID_COLLISION)}"
+            )
+        updated = replace(cfg, email_collision=value)  # type: ignore[arg-type]
+    save(updated)
+```
+
+- [ ] **Step 4: Run tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_config.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Lint**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add zehut/config.py tests/unit/test_config.py
+git commit -m "feat(config): typed Config dataclass with load/save/set_key and schema validation"
+```
+
+---
+
+## Task 5: `zehut.cli._errors` + `zehut.cli._output` — structured errors and output
+
+**Goal:** Every handler raises `ZehutError(code, message, remediation)`. One emitter writes either text (human) or JSON (`--json`). No Python tracebacks ever reach stderr.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/cli/_errors.py`
+- Create: `/home/spark/git/zehut/zehut/cli/_output.py`
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/__init__.py` (empty — needed so Task 6 can import)
+- Create: `/home/spark/git/zehut/tests/unit/test_cli_errors.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_cli_output.py`
+
+- [ ] **Step 1: Write failing tests for `_errors`**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cli_errors.py`
+
+```python
+"""Unit tests for zehut.cli._errors."""
+
+from __future__ import annotations
+
+from zehut.cli import _errors
+
+
+def test_exit_code_constants():
+    assert _errors.EXIT_SUCCESS == 0
+    assert _errors.EXIT_USER_ERROR == 64
+    assert _errors.EXIT_STATE == 65
+    assert _errors.EXIT_PRIVILEGE == 66
+    assert _errors.EXIT_BACKEND == 67
+    assert _errors.EXIT_CONFLICT == 68
+    assert _errors.EXIT_INTERNAL == 70
+
+
+def test_zehut_error_fields():
+    err = _errors.ZehutError(
+        code=_errors.EXIT_USER_ERROR,
+        message="no such user",
+        remediation="zehut user list",
+    )
+    assert err.code == 64
+    assert err.message == "no such user"
+    assert err.remediation == "zehut user list"
+    assert isinstance(err, Exception)
+
+
+def test_zehut_error_str_is_message():
+    err = _errors.ZehutError(code=64, message="msg", remediation="r")
+    assert str(err) == "msg"
+```
+
+- [ ] **Step 2: Write failing tests for `_output`**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cli_output.py`
+
+```python
+"""Unit tests for zehut.cli._output."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from zehut.cli import _errors, _output
+
+
+def test_emit_result_text_prints_to_stdout(capsys):
+    _output.emit_result("hello", json_mode=False)
+    cap = capsys.readouterr()
+    assert cap.out == "hello\n"
+    assert cap.err == ""
+
+
+def test_emit_result_json_prints_compact_json(capsys):
+    _output.emit_result({"a": 1}, json_mode=True)
+    cap = capsys.readouterr()
+    assert json.loads(cap.out) == {"a": 1}
+    assert cap.err == ""
+
+
+def test_emit_diagnostic_goes_to_stderr(capsys):
+    _output.emit_diagnostic("heads up", json_mode=False)
+    cap = capsys.readouterr()
+    assert cap.out == ""
+    assert "heads up" in cap.err
+
+
+def test_emit_error_text_format(capsys):
+    err = _errors.ZehutError(code=64, message="no such user", remediation="zehut user list")
+    _output.emit_error(err, json_mode=False)
+    cap = capsys.readouterr()
+    assert cap.out == ""
+    assert "error: no such user" in cap.err
+    assert "hint: zehut user list" in cap.err
+
+
+def test_emit_error_json_shape(capsys):
+    err = _errors.ZehutError(code=68, message="collision", remediation="pick a distinct --nick")
+    _output.emit_error(err, json_mode=True)
+    cap = capsys.readouterr()
+    payload = json.loads(cap.err)
+    assert payload == {
+        "error": "collision",
+        "code": 68,
+        "hint": "pick a distinct --nick",
+    }
+```
+
+- [ ] **Step 3: Run tests (expect failure)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cli_errors.py tests/unit/test_cli_output.py -v
+```
+
+Expected: ImportError / ModuleNotFoundError on the two modules.
+
+- [ ] **Step 4: Implement `zehut/cli/_errors.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_errors.py`
+
+```python
+"""Structured error type + exit-code constants.
+
+Every CLI handler that fails raises :class:`ZehutError`. ``zehut.cli.main``
+catches it, routes through :mod:`zehut.cli._output`, and exits with the
+embedded code. Python tracebacks never reach the user; unknown exceptions
+are wrapped into ``ZehutError(EXIT_INTERNAL, ...)`` at the top level.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 64
+EXIT_STATE = 65
+EXIT_PRIVILEGE = 66
+EXIT_BACKEND = 67
+EXIT_CONFLICT = 68
+EXIT_INTERNAL = 70
+
+
+@dataclass
+class ZehutError(Exception):
+    code: int
+    message: str
+    remediation: str
+
+    def __str__(self) -> str:
+        return self.message
+```
+
+- [ ] **Step 5: Implement `zehut/cli/_output.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_output.py`
+
+```python
+"""stdout/stderr split + JSON switch for all CLI output.
+
+Contract:
+
+* **results** → stdout (``emit_result``). Anything a downstream tool or
+  pipe would want to consume.
+* **diagnostics** → stderr (``emit_diagnostic``). Progress, warnings, side
+  info. Always safe to suppress.
+* **errors** → stderr (``emit_error``). Human form is
+  ``error: <msg>\\nhint: <remediation>``; JSON form is
+  ``{"error": msg, "code": N, "hint": remediation}``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from zehut.cli._errors import ZehutError
+
+
+def emit_result(value: Any, *, json_mode: bool) -> None:
+    if json_mode:
+        sys.stdout.write(json.dumps(value, separators=(",", ":"), default=str))
+        sys.stdout.write("\n")
+    else:
+        if isinstance(value, str):
+            sys.stdout.write(value)
+            if not value.endswith("\n"):
+                sys.stdout.write("\n")
+        else:
+            sys.stdout.write(f"{value}\n")
+
+
+def emit_diagnostic(message: str, *, json_mode: bool) -> None:
+    if json_mode:
+        sys.stderr.write(json.dumps({"diagnostic": message}, separators=(",", ":")))
+        sys.stderr.write("\n")
+    else:
+        sys.stderr.write(f"{message}\n")
+
+
+def emit_error(err: ZehutError, *, json_mode: bool) -> None:
+    if json_mode:
+        payload = {"error": err.message, "code": err.code, "hint": err.remediation}
+        sys.stderr.write(json.dumps(payload, separators=(",", ":")))
+        sys.stderr.write("\n")
+    else:
+        sys.stderr.write(f"error: {err.message}\n")
+        if err.remediation:
+            sys.stderr.write(f"hint: {err.remediation}\n")
+```
+
+- [ ] **Step 6: Create empty `_commands` package marker**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/__init__.py` — empty file.
+
+- [ ] **Step 7: Run tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cli_errors.py tests/unit/test_cli_output.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_errors.py zehut/cli/_output.py zehut/cli/_commands/__init__.py \
+        tests/unit/test_cli_errors.py tests/unit/test_cli_output.py
+git commit -m "feat(cli): structured error type + text/JSON output plumbing"
+```
+
+---
+
+## Task 6: `zehut.cli.__init__` — argparse framework, dispatch, error routing
+
+**Goal:** Real `main()` replaces the Task 1 placeholder. Error-routing ArgumentParser (matches afi-cli's `_AfiArgumentParser`), lazy-imported noun groups, `--json` pre-peek, catch-all wrapping.
+
+**Files:**
+- Modify (full rewrite): `/home/spark/git/zehut/zehut/cli/__init__.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_cli_framework.py`
+
+Later tasks will wire individual noun groups into `_build_parser`. For now the parser exposes only `--version` and `--json` at the top level; any subcommand attempt returns `EXIT_USER_ERROR` via the structured path.
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cli_framework.py`
+
+```python
+"""Unit tests for zehut.cli — parser, dispatch, main()."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli
+from zehut.cli import _errors
+
+
+def test_main_version_prints_and_returns_zero(capsys):
+    rc = cli.main(["--version"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "zehut" in cap.out
+
+
+def test_main_no_args_prints_help_and_returns_zero(capsys):
+    rc = cli.main([])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "usage:" in cap.out.lower() or "usage:" in cap.err.lower()
+
+
+def test_main_unknown_subcommand_returns_user_error_text(capsys):
+    rc = cli.main(["ghostverb"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+    assert "error:" in cap.err
+    assert "hint:" in cap.err
+
+
+def test_main_unknown_subcommand_returns_user_error_json(capsys):
+    rc = cli.main(["--json", "ghostverb"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+    payload = json.loads(cap.err.splitlines()[-1])
+    assert payload["code"] == _errors.EXIT_USER_ERROR
+    assert "error" in payload
+    assert "hint" in payload
+
+
+def test_dispatch_wraps_unexpected_exception_as_internal(capsys):
+    def boom(_args):
+        raise RuntimeError("kaboom")
+
+    import argparse
+    ns = argparse.Namespace(func=boom, json=False)
+    rc = cli._dispatch(ns)
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_INTERNAL
+    assert "kaboom" in cap.err
+    # Traceback must not leak.
+    assert "Traceback" not in cap.err
+
+
+def test_dispatch_handles_zehut_error(capsys):
+    def raiser(_args):
+        raise _errors.ZehutError(
+            code=_errors.EXIT_CONFLICT, message="collision", remediation="retry"
+        )
+
+    import argparse
+    ns = argparse.Namespace(func=raiser, json=False)
+    rc = cli._dispatch(ns)
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_CONFLICT
+    assert "collision" in cap.err
+    assert "retry" in cap.err
+```
+
+- [ ] **Step 2: Run tests (expect failure on the new assertions — current placeholder returns 0)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cli_framework.py -v
+```
+
+Expected: several failures (placeholder main prints a stub message and always returns 0).
+
+- [ ] **Step 3: Rewrite `zehut/cli/__init__.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py`
+
+```python
+"""Unified CLI entry point — parser, dispatcher, error routing.
+
+Mirrors ``afi-cli``'s ``afi.cli`` module:
+
+* Every argparse error routes through :func:`_output.emit_error` via a
+  subclassed parser. This produces structured errors (text or JSON) with
+  remediation hints instead of argparse's default ``prog: error:`` line.
+* Handlers raise :class:`ZehutError`; :func:`_dispatch` catches and emits.
+* Unknown exceptions are wrapped as ``EXIT_INTERNAL`` so no Python
+  traceback ever reaches the user.
+* Noun groups (``user``, ``configuration``) register themselves via a
+  ``register(subparsers)`` function — wired in later tasks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from zehut import __version__
+from zehut.cli._errors import (
+    EXIT_INTERNAL,
+    EXIT_USER_ERROR,
+    ZehutError,
+)
+from zehut.cli._output import emit_error
+
+
+class _ZehutArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that routes errors through :func:`emit_error`.
+
+    Argparse's default ``error()`` writes ``prog: error: <msg>`` and exits.
+    That skips our ZehutError plumbing (no hint, wrong exit code). This
+    subclass emits the structured format and exits with
+    ``EXIT_USER_ERROR``.
+
+    JSON mode: parse-time errors happen before ``args.json`` exists, so we
+    rely on ``_json_hint`` that :func:`main` pre-populates by peeking at
+    argv for ``--json`` / ``--json=…``.
+    """
+
+    _json_hint: bool = False
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        err = ZehutError(
+            code=EXIT_USER_ERROR,
+            message=message,
+            remediation=f"run '{self.prog} --help' to see valid arguments",
+        )
+        emit_error(err, json_mode=type(self)._json_hint)
+        raise SystemExit(err.code)
+
+
+def _argv_has_json(argv: list[str] | None) -> bool:
+    tokens = argv if argv is not None else sys.argv[1:]
+    return any(t == "--json" or t.startswith("--json=") for t in tokens)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = _ZehutArgumentParser(
+        prog="zehut",
+        description="zehut — agents-first identity layer",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit structured JSON for results and errors.",
+    )
+    # parser_class propagates to every subparser so .error() routes through
+    # _ZehutArgumentParser everywhere.
+    parser.add_subparsers(dest="command", parser_class=_ZehutArgumentParser)
+    # Noun groups register here in later tasks (user, configuration),
+    # along with globals (init, doctor, learn, overview, explain).
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    """Invoke the registered handler; translate exceptions to exit codes."""
+    json_mode = bool(getattr(args, "json", False))
+    func = getattr(args, "func", None)
+    if func is None:
+        # No subcommand selected — caller should have printed help.
+        return 0
+    try:
+        rc = func(args)
+    except ZehutError as err:
+        emit_error(err, json_mode=json_mode)
+        return err.code
+    except SystemExit:  # pragma: no cover — let argparse exits propagate
+        raise
+    except Exception as err:  # noqa: BLE001 — last-resort wrap
+        wrapped = ZehutError(
+            code=EXIT_INTERNAL,
+            message=f"unexpected: {err.__class__.__name__}: {err}",
+            remediation="file a bug at https://github.com/OriNachum/zehut/issues",
+        )
+        emit_error(wrapped, json_mode=json_mode)
+        return wrapped.code
+    return rc if rc is not None else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _ZehutArgumentParser._json_hint = _argv_has_json(argv)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if getattr(args, "command", None) is None:
+        parser.print_help()
+        return 0
+    return _dispatch(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cli_framework.py tests/test_smoke.py -v
+```
+
+Expected: all tests pass, including the smoke test's `--version` call.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/__init__.py tests/unit/test_cli_framework.py
+git commit -m "feat(cli): argparse framework with structured error routing + --json"
+```
+
+---
+
+## Task 7: `zehut.backend` — Backend ABC + logical strategy
+
+**Goal:** One interface, two implementations. `LogicalBackend` is a no-op for the OS layer (pure metadata). The `SystemBackend` (Task 8) will wrap `useradd`/`userdel`.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/backend/__init__.py`
+- Create: `/home/spark/git/zehut/zehut/backend/base.py`
+- Create: `/home/spark/git/zehut/zehut/backend/logical.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_backend_logical.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_backend_logical.py`
+
+```python
+"""Unit tests for zehut.backend.logical."""
+
+from __future__ import annotations
+
+import pytest
+
+from zehut.backend import logical
+from zehut.backend.base import Backend, ProvisionResult
+
+
+def test_logical_backend_is_a_backend():
+    assert isinstance(logical.LogicalBackend(), Backend)
+
+
+def test_provision_returns_result_with_no_system_uid():
+    be = logical.LogicalBackend()
+    result = be.provision(name="alice")
+    assert isinstance(result, ProvisionResult)
+    assert result.system_user is None
+    assert result.system_uid is None
+
+
+def test_deprovision_is_a_noop():
+    be = logical.LogicalBackend()
+    # Should not raise regardless of whether 'alice' exists anywhere.
+    be.deprovision(name="alice", system_user=None, keep_home=False)
+
+
+def test_exists_returns_false_for_any_name():
+    be = logical.LogicalBackend()
+    assert be.exists("alice") is False
+    assert be.exists("root") is False
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_backend_logical.py -v
+```
+
+Expected: ImportError on `zehut.backend`.
+
+- [ ] **Step 3: Implement `zehut/backend/__init__.py`**
+
+Path: `/home/spark/git/zehut/zehut/backend/__init__.py`
+
+```python
+"""Backend strategies — ``system`` and ``logical``.
+
+Both share the :class:`~zehut.backend.base.Backend` ABC so
+``zehut.users`` can treat them uniformly.
+"""
+
+from __future__ import annotations
+
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.backend.logical import LogicalBackend
+
+__all__ = ["Backend", "ProvisionResult", "LogicalBackend"]
+```
+
+- [ ] **Step 4: Implement `zehut/backend/base.py`**
+
+Path: `/home/spark/git/zehut/zehut/backend/base.py`
+
+```python
+"""Backend ABC and shared types.
+
+A backend encapsulates OS-level identity plumbing: creation, deletion,
+existence checks. ``zehut.users`` owns the registry (metadata) and calls
+into a backend for the OS side.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    """Outcome of a successful provision."""
+
+    system_user: str | None
+    system_uid: int | None
+
+
+class Backend(ABC):
+    """Abstract backend interface."""
+
+    @abstractmethod
+    def provision(self, *, name: str) -> ProvisionResult: ...
+
+    @abstractmethod
+    def deprovision(
+        self, *, name: str, system_user: str | None, keep_home: bool
+    ) -> None: ...
+
+    @abstractmethod
+    def exists(self, name: str) -> bool: ...
+```
+
+- [ ] **Step 5: Implement `zehut/backend/logical.py`**
+
+Path: `/home/spark/git/zehut/zehut/backend/logical.py`
+
+```python
+"""Logical (metadata-only) backend.
+
+A logical identity has no OS account; it exists purely in the zehut
+registry. ``provision`` and ``deprovision`` are no-ops at the OS layer;
+``exists`` always returns ``False`` because we define "exists" as "has an
+OS presence", which logical identities never do.
+"""
+
+from __future__ import annotations
+
+from zehut.backend.base import Backend, ProvisionResult
+
+
+class LogicalBackend(Backend):
+    def provision(self, *, name: str) -> ProvisionResult:
+        return ProvisionResult(system_user=None, system_uid=None)
+
+    def deprovision(
+        self, *, name: str, system_user: str | None, keep_home: bool
+    ) -> None:
+        return None
+
+    def exists(self, name: str) -> bool:
+        return False
+```
+
+- [ ] **Step 6: Run tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_backend_logical.py -v
+```
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/backend/ tests/unit/test_backend_logical.py
+git commit -m "feat(backend): ABC + logical backend (metadata-only, no OS calls)"
+```
+
+---
+
+## Task 8: `zehut.backend.system` — `useradd`/`userdel` wrapper
+
+**Goal:** The only place in zehut that shells out to OS user-management tools. Fully mockable in unit tests; gated integration tests exercise the real binaries in CI's Docker container.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/backend/system.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_backend_system.py`
+- Create: `/home/spark/git/zehut/tests/integration/test_backend_system_integration.py`
+- Modify: `/home/spark/git/zehut/zehut/backend/__init__.py` — re-export `SystemBackend`.
+
+**Design choices captured from spec §10 (open implementation questions):**
+- `PATH` pinned to `/usr/sbin:/usr/bin` for every `subprocess.run` call — addresses threat-model risk #1.
+- `useradd` flags: `-m` (create homedir), `-U` (create matching primary group), `-s /bin/bash` (explicit shell; safer than relying on `/etc/default/useradd`).
+- `userdel` flags: `-r` by default (remove homedir), `keep_home=True` drops the `-r`.
+- Name validation: must match `^[a-z_][a-z0-9_-]{0,31}$` (POSIX useradd typical constraint) — rejected early with `ZehutError(EXIT_USER_ERROR)` instead of relying on useradd's error message.
+
+- [ ] **Step 1: Write failing unit tests (mocked subprocess)**
+
+Path: `/home/spark/git/zehut/tests/unit/test_backend_system.py`
+
+```python
+"""Unit tests for zehut.backend.system — all subprocess calls mocked."""
+
+from __future__ import annotations
+
+import subprocess
+import types
+
+import pytest
+
+from zehut.backend import system
+from zehut.backend.base import ProvisionResult
+from zehut.cli._errors import EXIT_BACKEND, EXIT_USER_ERROR, ZehutError
+
+
+@pytest.fixture
+def fake_pwd(monkeypatch):
+    """Install a fake ``pwd.getpwnam`` that returns a predictable record."""
+    entries: dict[str, int] = {}
+
+    def _getpwnam(name: str):
+        if name not in entries:
+            raise KeyError(name)
+        return types.SimpleNamespace(pw_name=name, pw_uid=entries[name])
+
+    monkeypatch.setattr(system.pwd, "getpwnam", _getpwnam)
+    return entries
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Record subprocess.run calls and simulate success."""
+    calls: list[list[str]] = []
+
+    def _run(args, *, check, env, stdout, stderr):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, b"", b"")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    return calls
+
+
+def test_provision_rejects_bad_name(fake_pwd, fake_run):
+    be = system.SystemBackend()
+    with pytest.raises(ZehutError) as exc:
+        be.provision(name="WithCaps")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "name" in exc.value.message.lower()
+
+
+def test_provision_calls_useradd_with_expected_flags(fake_pwd, fake_run):
+    fake_pwd["alice"] = 1001
+    be = system.SystemBackend()
+    result = be.provision(name="alice")
+    assert isinstance(result, ProvisionResult)
+    assert result.system_user == "alice"
+    assert result.system_uid == 1001
+    assert fake_run == [["useradd", "-m", "-U", "-s", "/bin/bash", "alice"]]
+
+
+def test_provision_pins_path(monkeypatch, fake_pwd):
+    """useradd must be invoked with PATH = /usr/sbin:/usr/bin."""
+    seen_env: dict[str, str] = {}
+
+    def _run(args, *, check, env, stdout, stderr):
+        seen_env.update(env or {})
+        return subprocess.CompletedProcess(args, 0, b"", b"")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    fake_pwd["alice"] = 1001
+    system.SystemBackend().provision(name="alice")
+    assert seen_env.get("PATH") == "/usr/sbin:/usr/bin"
+
+
+def test_provision_raises_backend_on_nonzero_useradd(monkeypatch, fake_pwd):
+    def _run(args, *, check, env, stdout, stderr):
+        return subprocess.CompletedProcess(args, 9, b"", b"useradd: user 'alice' already exists\n")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    be = system.SystemBackend()
+    with pytest.raises(ZehutError) as exc:
+        be.provision(name="alice")
+    assert exc.value.code == EXIT_BACKEND
+    assert "useradd" in exc.value.message.lower()
+
+
+def test_deprovision_calls_userdel_with_dash_r_by_default(fake_run):
+    system.SystemBackend().deprovision(name="alice", system_user="alice", keep_home=False)
+    assert fake_run == [["userdel", "-r", "alice"]]
+
+
+def test_deprovision_keep_home_drops_dash_r(fake_run):
+    system.SystemBackend().deprovision(name="alice", system_user="alice", keep_home=True)
+    assert fake_run == [["userdel", "alice"]]
+
+
+def test_deprovision_raises_backend_on_nonzero_userdel(monkeypatch):
+    def _run(args, *, check, env, stdout, stderr):
+        return subprocess.CompletedProcess(args, 6, b"", b"userdel: user 'alice' does not exist\n")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    with pytest.raises(ZehutError) as exc:
+        system.SystemBackend().deprovision(name="alice", system_user="alice", keep_home=False)
+    assert exc.value.code == EXIT_BACKEND
+
+
+def test_exists_consults_pwd(fake_pwd):
+    fake_pwd["alice"] = 1001
+    be = system.SystemBackend()
+    assert be.exists("alice") is True
+    assert be.exists("ghost") is False
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_backend_system.py -v
+```
+
+Expected: ImportError on `zehut.backend.system`.
+
+- [ ] **Step 3: Implement `zehut/backend/system.py`**
+
+Path: `/home/spark/git/zehut/zehut/backend/system.py`
+
+```python
+"""System backend — wraps ``useradd`` and ``userdel``.
+
+The only place in zehut that invokes these binaries. ``PATH`` is pinned to
+``/usr/sbin:/usr/bin`` on every call so malicious shadowing in a
+privileged caller's environment cannot redirect us to a different binary.
+Names are validated against a conservative POSIX-shaped pattern before
+any subprocess is spawned.
+"""
+
+from __future__ import annotations
+
+import pwd
+import re
+import subprocess
+
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.cli._errors import EXIT_BACKEND, EXIT_USER_ERROR, ZehutError
+
+_NAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+_SAFE_PATH = "/usr/sbin:/usr/bin"
+
+
+def _validate_name(name: str) -> None:
+    if not _NAME_RE.match(name):
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"invalid user name {name!r}: must match ^[a-z_][a-z0-9_-]{{0,31}}$"
+            ),
+            remediation="pick a POSIX-compliant user name (lowercase, digits, dash, underscore)",
+        )
+
+
+def _run(cmd: list[str], *, what: str) -> None:
+    result = subprocess.run(
+        cmd,
+        check=False,
+        env={"PATH": _SAFE_PATH, "LC_ALL": "C"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise ZehutError(
+            code=EXIT_BACKEND,
+            message=f"{what} failed (exit {result.returncode}): {stderr or '<no output>'}",
+            remediation=f"inspect system logs and re-run {cmd[0]} manually to reproduce",
+        )
+
+
+class SystemBackend(Backend):
+    def provision(self, *, name: str) -> ProvisionResult:
+        _validate_name(name)
+        _run(["useradd", "-m", "-U", "-s", "/bin/bash", name], what="useradd")
+        try:
+            entry = pwd.getpwnam(name)
+        except KeyError as err:  # pragma: no cover — very unlikely after successful useradd
+            raise ZehutError(
+                code=EXIT_BACKEND,
+                message=f"useradd succeeded but {name!r} not found in pwd database",
+                remediation="run 'getent passwd' and 'zehut doctor' to diagnose",
+            ) from err
+        return ProvisionResult(system_user=entry.pw_name, system_uid=entry.pw_uid)
+
+    def deprovision(
+        self, *, name: str, system_user: str | None, keep_home: bool
+    ) -> None:
+        target = system_user or name
+        _validate_name(target)
+        cmd = ["userdel"]
+        if not keep_home:
+            cmd.append("-r")
+        cmd.append(target)
+        _run(cmd, what="userdel")
+
+    def exists(self, name: str) -> bool:
+        try:
+            pwd.getpwnam(name)
+        except KeyError:
+            return False
+        return True
+```
+
+- [ ] **Step 4: Update `zehut/backend/__init__.py` to re-export SystemBackend**
+
+Path: `/home/spark/git/zehut/zehut/backend/__init__.py`
+
+```python
+"""Backend strategies — ``system`` and ``logical``."""
+
+from __future__ import annotations
+
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.backend.logical import LogicalBackend
+from zehut.backend.system import SystemBackend
+
+__all__ = ["Backend", "ProvisionResult", "LogicalBackend", "SystemBackend"]
+```
+
+- [ ] **Step 5: Write the gated integration test**
+
+Path: `/home/spark/git/zehut/tests/integration/test_backend_system_integration.py`
+
+```python
+"""Integration tests for SystemBackend — requires real useradd/userdel.
+
+Gated: only runs as root OR when ``ZEHUT_DOCKER=1`` is set. CI runs these
+inside a disposable container. Local dev machines skip them by default.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import uuid
+
+import pytest
+
+from zehut.backend.system import SystemBackend
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.geteuid() != 0 and os.environ.get("ZEHUT_DOCKER") != "1",
+        reason="requires root or ZEHUT_DOCKER=1",
+    ),
+]
+
+
+def _unique_name() -> str:
+    # useradd caps names at 32; take an 8-char hex chunk.
+    return "zht" + uuid.uuid4().hex[:8]
+
+
+def test_provision_then_deprovision_roundtrip():
+    name = _unique_name()
+    be = SystemBackend()
+    try:
+        result = be.provision(name=name)
+        assert result.system_user == name
+        assert isinstance(result.system_uid, int)
+        assert be.exists(name) is True
+        assert pwd.getpwnam(name).pw_uid == result.system_uid
+    finally:
+        if be.exists(name):
+            be.deprovision(name=name, system_user=name, keep_home=False)
+    assert be.exists(name) is False
+```
+
+- [ ] **Step 6: Run unit tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_backend_system.py -v
+```
+
+Integration tests will be skipped unless you set `ZEHUT_DOCKER=1`; that's fine — the CI harness in Task 18 runs them.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/backend/system.py zehut/backend/__init__.py \
+        tests/unit/test_backend_system.py tests/integration/test_backend_system_integration.py
+git commit -m "feat(backend): system backend wraps useradd/userdel with PATH pinning + name validation"
+```
+
+---
+
+## Task 9: `zehut.users` — registry CRUD, ULID, email generation
+
+**Goal:** The module that owns `users.json`. Every read/write goes through here. Backend is injected so the registry itself is pure and testable.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/users.py`
+- Create: `/home/spark/git/zehut/tests/unit/test_users.py`
+
+**Design choices:**
+- **ULID generator:** hand-rolled ~30-line implementation (Crockford base32 encoding of 48-bit timestamp + 80 random bits). Keeps the zero-runtime-deps promise. Determinism in tests is achieved by monkey-patching `users._generate_ulid`.
+- **Email generation tokens:** `{name}`, `{nick}`, `{id-short}` (first 8 chars of ULID), and the fallback syntax `{nick|name}` — first non-empty wins. Implemented with a small tokenizer, not `str.format`, because `str.format` doesn't support the fallback operator.
+- **Collision resolution:** when the generated email already exists in the registry, append `-2`, `-3`, … up to `-99`; beyond that, raise `EXIT_CONFLICT`.
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_users.py`
+
+```python
+"""Unit tests for zehut.users — registry CRUD + email generation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import config, fs, users
+from zehut.backend.logical import LogicalBackend
+from zehut.cli._errors import EXIT_CONFLICT, EXIT_STATE, EXIT_USER_ERROR, ZehutError
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    cfg = config.Config.default(domain="agents.example.com", backend="logical")
+    config.save(cfg)
+    users.init_registry()
+    return config_dir, state_dir
+
+
+# --- email generation ---------------------------------------------------------
+
+def test_render_email_single_token(tmp_zehut):
+    assert users.render_email("{name}", name="alice", nick="", domain="x.com") == "alice@x.com"
+
+
+def test_render_email_nick_fallback_operator(tmp_zehut):
+    # Nick present → use it.
+    assert users.render_email("{nick|name}", name="alice", nick="ali", domain="x.com") == "ali@x.com"
+    # Nick empty → fall back to name.
+    assert users.render_email("{nick|name}", name="alice", nick="", domain="x.com") == "alice@x.com"
+
+
+def test_render_email_id_short_token(tmp_zehut):
+    email = users.render_email(
+        "{id-short}", name="alice", nick="", domain="x.com", id_short="01HYA9ZZ"
+    )
+    assert email == "01HYA9ZZ@x.com"
+
+
+def test_render_email_empty_result_raises(tmp_zehut):
+    with pytest.raises(ZehutError) as exc:
+        users.render_email("{nick}", name="alice", nick="", domain="x.com")
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+# --- registry CRUD ------------------------------------------------------------
+
+def test_init_registry_creates_empty_file(tmp_zehut):
+    _, state_dir = tmp_zehut
+    path = state_dir / "users.json"
+    assert path.exists()
+    assert fs.read_json(path) == {"schema_version": 1, "users": []}
+
+
+def test_add_then_list(tmp_zehut):
+    be = LogicalBackend()
+    rec = users.add(name="alice", nick="Ali", about="qa", backend_name="logical", backend=be)
+    assert rec.name == "alice"
+    assert rec.backend == "logical"
+    assert rec.email.endswith("@agents.example.com")
+    lst = users.list_all()
+    assert len(lst) == 1
+    assert lst[0].name == "alice"
+
+
+def test_add_duplicate_name_raises_conflict(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    with pytest.raises(ZehutError) as exc:
+        users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    assert exc.value.code == EXIT_CONFLICT
+
+
+def test_add_email_collision_appends_suffix(tmp_zehut, monkeypatch):
+    # Force every render to produce "ali@..." so collisions happen.
+    monkeypatch.setattr(
+        users, "render_email", lambda pattern, **kw: f"ali@{kw['domain']}"
+    )
+    be = LogicalBackend()
+    r1 = users.add(name="alice", nick="Ali", about=None, backend_name="logical", backend=be)
+    r2 = users.add(name="alice2", nick="Ali", about=None, backend_name="logical", backend=be)
+    assert r1.email == "ali@agents.example.com"
+    assert r2.email == "ali-2@agents.example.com"
+
+
+def test_get_returns_record(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    rec = users.get("alice")
+    assert rec.name == "alice"
+
+
+def test_get_missing_raises_user_error(tmp_zehut):
+    with pytest.raises(ZehutError) as exc:
+        users.get("ghost")
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_update_sets_nick_and_about(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    users.update("alice", nick="Ali", about="qa agent")
+    rec = users.get("alice")
+    assert rec.nick == "Ali"
+    assert rec.about == "qa agent"
+
+
+def test_update_rejects_immutable_keys(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    with pytest.raises(ZehutError) as exc:
+        users.update("alice", email="other@x.com")
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_remove_drops_record(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    users.remove("alice", backend=be, keep_home=False)
+    assert users.list_all() == []
+
+
+def test_registry_load_rejects_wrong_schema(tmp_zehut):
+    _, state_dir = tmp_zehut
+    fs.atomic_write_text(
+        state_dir / "users.json",
+        json.dumps({"schema_version": 2, "users": []}),
+        mode=0o644,
+    )
+    with pytest.raises(ZehutError) as exc:
+        users.list_all()
+    assert exc.value.code == EXIT_STATE
+
+
+def test_ulid_is_26_crockford_chars(tmp_zehut):
+    u = users._generate_ulid()
+    assert len(u) == 26
+    assert set(u).issubset(set("0123456789ABCDEFGHJKMNPQRSTVWXYZ"))
+```
+
+- [ ] **Step 2: Run tests (expect failure)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_users.py -v
+```
+
+Expected: ImportError on `zehut.users`.
+
+- [ ] **Step 3: Implement `zehut/users.py`**
+
+Path: `/home/spark/git/zehut/zehut/users.py`
+
+```python
+"""User registry — CRUD over ``/var/lib/zehut/users.json``.
+
+Every mutation takes the advisory exclusive lock at ``fs.lock_file()``
+and writes atomically via ``fs.atomic_write_text``. Backend calls happen
+while the lock is held so registry state and OS state cannot diverge due
+to a concurrent race inside zehut.
+
+Transactional ordering (spec §5.5):
+
+* ``add`` with system backend: ``backend.provision`` → registry write.
+  If the write crashes, a later ``zehut doctor`` detects the orphan OS
+  user. (No registry entry ever points at a missing uid.)
+* ``remove`` with system backend: registry write → ``backend.deprovision``.
+  If deprovision crashes, the registry is clean; ``doctor`` detects the
+  orphan OS user.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import time
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Any
+
+from zehut import config, fs
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.cli._errors import (
+    EXIT_CONFLICT,
+    EXIT_STATE,
+    EXIT_USER_ERROR,
+    ZehutError,
+)
+
+_SCHEMA_VERSION = 1
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_NAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+_EMAIL_DOMAIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_MUTABLE_KEYS = frozenset({"nick", "about"})
+_MAX_EMAIL_SUFFIX = 99
+
+
+@dataclass(frozen=True)
+class UserRecord:
+    id: str
+    name: str
+    nick: str | None
+    about: str | None
+    email: str
+    backend: str
+    system_user: str | None
+    system_uid: int | None
+    created_at: str
+    updated_at: str
+
+
+# --- ULID ---------------------------------------------------------------------
+
+def _generate_ulid() -> str:
+    """Generate a 26-char Crockford-base32 ULID. No external deps."""
+    ts_ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    rand = secrets.randbits(80)
+    combined = (ts_ms << 80) | rand
+    out: list[str] = []
+    for _ in range(26):
+        out.append(_CROCKFORD[combined & 0x1F])
+        combined >>= 5
+    return "".join(reversed(out))
+
+
+# --- email rendering ----------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"\{([^}]+)\}")
+
+
+def render_email(
+    pattern: str,
+    *,
+    name: str,
+    nick: str | None,
+    domain: str,
+    id_short: str = "",
+) -> str:
+    """Render an email local-part from ``pattern`` and join with ``domain``.
+
+    Supports single tokens ``{name}``, ``{nick}``, ``{id-short}`` and the
+    fallback syntax ``{a|b|c}`` — first non-empty source wins.
+    """
+    sources: dict[str, str] = {
+        "name": name or "",
+        "nick": nick or "",
+        "id-short": id_short or "",
+    }
+
+    def _replace(match: "re.Match[str]") -> str:
+        spec = match.group(1)
+        for key in spec.split("|"):
+            key = key.strip()
+            if key in sources and sources[key]:
+                return sources[key]
+        return ""
+
+    local = _TOKEN_RE.sub(_replace, pattern).strip()
+    if not local:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"email pattern {pattern!r} produced an empty local-part "
+                f"(name={name!r}, nick={nick!r})"
+            ),
+            remediation="set --nick or change configuration.email_pattern",
+        )
+    if not _EMAIL_DOMAIN_RE.match(domain):
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=f"invalid configured domain {domain!r}",
+            remediation="fix with: sudo zehut configuration set-domain <domain>",
+        )
+    return f"{local}@{domain}"
+
+
+# --- registry load/save -------------------------------------------------------
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _empty_registry() -> dict[str, Any]:
+    return {"schema_version": _SCHEMA_VERSION, "users": []}
+
+
+def init_registry() -> None:
+    """Create an empty registry file if it doesn't already exist."""
+    path = fs.users_file()
+    if path.exists():
+        return
+    import json
+
+    fs.atomic_write_text(path, json.dumps(_empty_registry(), indent=2), mode=0o644)
+
+
+def _load_raw() -> dict[str, Any]:
+    path = fs.users_file()
+    try:
+        doc = fs.read_json(path)
+    except FileNotFoundError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=f"users registry missing at {path}",
+            remediation="run: sudo zehut init",
+        ) from err
+    if doc.get("schema_version") != _SCHEMA_VERSION:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=(
+                f"unsupported users.json schema_version {doc.get('schema_version')!r}; "
+                f"expected {_SCHEMA_VERSION}"
+            ),
+            remediation="zehut migrate is not yet available (v1); re-init is destructive",
+        )
+    return doc
+
+
+def _save_raw(doc: dict[str, Any]) -> None:
+    import json
+
+    fs.atomic_write_text(fs.users_file(), json.dumps(doc, indent=2), mode=0o644)
+
+
+def _to_record(entry: dict[str, Any]) -> UserRecord:
+    return UserRecord(
+        id=entry["id"],
+        name=entry["name"],
+        nick=entry.get("nick"),
+        about=entry.get("about"),
+        email=entry["email"],
+        backend=entry["backend"],
+        system_user=entry.get("system_user"),
+        system_uid=entry.get("system_uid"),
+        created_at=entry["created_at"],
+        updated_at=entry["updated_at"],
+    )
+
+
+# --- public API ---------------------------------------------------------------
+
+def list_all() -> list[UserRecord]:
+    doc = _load_raw()
+    return [_to_record(e) for e in doc["users"]]
+
+
+def get(name: str) -> UserRecord:
+    for rec in list_all():
+        if rec.name == name:
+            return rec
+    raise ZehutError(
+        code=EXIT_USER_ERROR,
+        message=f"no such zehut user {name!r}",
+        remediation="list users with: zehut user list",
+    )
+
+
+def _allocate_email(base_email: str, existing_emails: set[str]) -> str:
+    if base_email not in existing_emails:
+        return base_email
+    local, at, domain = base_email.partition("@")
+    for n in range(2, _MAX_EMAIL_SUFFIX + 1):
+        candidate = f"{local}-{n}@{domain}"
+        if candidate not in existing_emails:
+            return candidate
+    raise ZehutError(
+        code=EXIT_CONFLICT,
+        message=f"email {base_email!r} collided beyond suffix limit {_MAX_EMAIL_SUFFIX}",
+        remediation="pass a distinct --nick or change configuration.email_pattern",
+    )
+
+
+def add(
+    *,
+    name: str,
+    nick: str | None,
+    about: str | None,
+    backend_name: str,
+    backend: Backend,
+) -> UserRecord:
+    if not _NAME_RE.match(name):
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"invalid user name {name!r}: must match ^[a-z_][a-z0-9_-]{{0,31}}$"
+            ),
+            remediation="pick a POSIX-compliant user name",
+        )
+    cfg = config.load()
+    with fs.exclusive_lock(fs.lock_file()):
+        doc = _load_raw()
+        existing_names = {e["name"] for e in doc["users"]}
+        if name in existing_names:
+            raise ZehutError(
+                code=EXIT_CONFLICT,
+                message=f"zehut user {name!r} already exists",
+                remediation="pick a different name or edit with: zehut user set",
+            )
+        new_id = _generate_ulid()
+        base_email = render_email(
+            cfg.email_pattern,
+            name=name,
+            nick=nick,
+            domain=cfg.domain,
+            id_short=new_id[:8],
+        )
+        existing_emails = {e["email"] for e in doc["users"]}
+        email = _allocate_email(base_email, existing_emails)
+
+        provision: ProvisionResult = backend.provision(name=name)
+        now = _now_iso()
+        entry = {
+            "id": new_id,
+            "name": name,
+            "nick": nick,
+            "about": about,
+            "email": email,
+            "backend": backend_name,
+            "system_user": provision.system_user,
+            "system_uid": provision.system_uid,
+            "created_at": now,
+            "updated_at": now,
+        }
+        doc["users"].append(entry)
+        _save_raw(doc)
+    return _to_record(entry)
+
+
+def update(name: str, **fields: Any) -> UserRecord:
+    unknown = set(fields) - _MUTABLE_KEYS
+    if unknown:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"cannot modify {sorted(unknown)}; mutable keys: {sorted(_MUTABLE_KEYS)}"
+            ),
+            remediation="backend, email, and system_user are immutable in v1",
+        )
+    with fs.exclusive_lock(fs.lock_file()):
+        doc = _load_raw()
+        for entry in doc["users"]:
+            if entry["name"] == name:
+                entry.update({k: v for k, v in fields.items() if k in _MUTABLE_KEYS})
+                entry["updated_at"] = _now_iso()
+                _save_raw(doc)
+                return _to_record(entry)
+    raise ZehutError(
+        code=EXIT_USER_ERROR,
+        message=f"no such zehut user {name!r}",
+        remediation="list users with: zehut user list",
+    )
+
+
+def remove(name: str, *, backend: Backend, keep_home: bool) -> None:
+    with fs.exclusive_lock(fs.lock_file()):
+        doc = _load_raw()
+        target = None
+        for entry in doc["users"]:
+            if entry["name"] == name:
+                target = entry
+                break
+        if target is None:
+            raise ZehutError(
+                code=EXIT_USER_ERROR,
+                message=f"no such zehut user {name!r}",
+                remediation="list users with: zehut user list",
+            )
+        doc["users"] = [e for e in doc["users"] if e["name"] != name]
+        _save_raw(doc)
+        try:
+            backend.deprovision(
+                name=name,
+                system_user=target.get("system_user"),
+                keep_home=keep_home,
+            )
+        except ZehutError:
+            # Registry is already clean; doctor will surface the orphan.
+            raise
+
+
+def ambient_name() -> str | None:
+    """Resolve the ambient identity name, or None.
+
+    Order (matches spec §3.4):
+
+    1. OS user matching a zehut-managed system-backed entry.
+    2. ``$ZEHUT_IDENTITY`` env var if it names an existing record.
+    3. ``None``.
+    """
+    try:
+        import pwd
+
+        os_name = pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        os_name = None
+    if os_name:
+        for rec in list_all():
+            if rec.backend == "system" and rec.system_user == os_name:
+                return rec.name
+    env_name = os.environ.get("ZEHUT_IDENTITY")
+    if env_name:
+        for rec in list_all():
+            if rec.name == env_name:
+                return rec.name
+    return None
+
+
+def record_to_dict(rec: UserRecord) -> dict[str, Any]:
+    return asdict(rec)
+```
+
+- [ ] **Step 4: Run tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_users.py -v
+```
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/users.py tests/unit/test_users.py
+git commit -m "feat(users): registry CRUD with ULID ids, email generation, ambient resolution"
+```
+
+---
+
+## Task 10: `zehut init` command
+
+**Goal:** Bootstrap `/etc/zehut/config.toml` and `/var/lib/zehut/users.json`. Prompts for `domain` and `default_backend`; flags available for non-interactive use. Idempotent — re-running without force is safe and reports "already initialised".
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/init.py`
+- Modify: `/home/spark/git/zehut/zehut/cli/__init__.py` — wire the new command.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_init.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_init.py`
+
+```python
+"""Unit tests for ``zehut init``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, config, fs, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    # Pretend we are root for these tests.
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    return config_dir, state_dir
+
+
+def test_init_non_interactive_writes_both_files(tmp_zehut, capsys):
+    rc = cli.main(["init", "--domain", "agents.example.com", "--default-backend", "system"])
+    assert rc == 0
+    cfg = config.load()
+    assert cfg.domain == "agents.example.com"
+    assert cfg.default_backend == "system"
+    assert users.list_all() == []
+
+
+def test_init_refuses_when_not_root(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["init", "--domain", "x.com", "--default-backend", "logical"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE
+    assert "sudo" in cap.err
+
+
+def test_init_is_idempotent_without_force(tmp_zehut, capsys):
+    cli.main(["init", "--domain", "x.com", "--default-backend", "logical"])
+    rc = cli.main(["init", "--domain", "ignored.com", "--default-backend", "system"])
+    assert rc == 0
+    assert config.load().domain == "x.com"  # unchanged
+
+
+def test_init_force_overwrites(tmp_zehut, capsys):
+    cli.main(["init", "--domain", "x.com", "--default-backend", "logical"])
+    rc = cli.main([
+        "init", "--force",
+        "--domain", "new.com",
+        "--default-backend", "system",
+    ])
+    assert rc == 0
+    assert config.load().domain == "new.com"
+
+
+def test_init_json_output(tmp_zehut, capsys):
+    rc = cli.main([
+        "--json", "init",
+        "--domain", "agents.example.com",
+        "--default-backend", "system",
+    ])
+    assert rc == 0
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["domain"] == "agents.example.com"
+    assert payload["default_backend"] == "system"
+    assert payload["initialised"] is True
+```
+
+- [ ] **Step 2: Implement `zehut/cli/_commands/init.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/init.py`
+
+```python
+"""``zehut init`` — bootstrap config + users registry.
+
+Idempotent by default: if state already exists, re-running without
+``--force`` is a no-op that reports the current configuration. With
+``--force``, the existing ``config.toml`` is rewritten and the registry
+file is (re)created empty only if no users exist; otherwise ``--force``
+still refuses to wipe data.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut import config, fs, privilege, users
+from zehut.cli._errors import EXIT_CONFLICT, EXIT_PRIVILEGE, ZehutError
+from zehut.cli._output import emit_diagnostic, emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("init", help="Bootstrap zehut state on this machine.")
+    p.add_argument("--domain", required=True, help="Email domain, e.g. agents.example.com")
+    p.add_argument(
+        "--default-backend",
+        required=True,
+        choices=("system", "logical"),
+        help="Default backend for 'zehut user create'.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing config.toml (never deletes users from a non-empty registry).",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        privilege.require_root(
+            action="write /etc/zehut and /var/lib/zehut",
+            argv=["init", "--domain", args.domain, "--default-backend", args.default_backend],
+        )
+    except privilege.PrivilegeError as err:
+        raise ZehutError(
+            code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+        ) from err
+
+    cfg_path = fs.config_file()
+    already = cfg_path.exists()
+    if already and not args.force:
+        emit_diagnostic(f"zehut already initialised at {cfg_path}", json_mode=json_mode)
+        existing = config.load()
+        users.init_registry()  # ensure users.json exists even after partial prior init
+        emit_result(
+            {
+                "initialised": False,
+                "domain": existing.domain,
+                "default_backend": existing.default_backend,
+                "config_path": str(cfg_path),
+                "users_path": str(fs.users_file()),
+            },
+            json_mode=json_mode,
+        )
+        return 0
+
+    if already and args.force:
+        # Guard: never wipe a non-empty registry implicitly.
+        try:
+            current = users.list_all()
+        except ZehutError:
+            current = []
+        if current:
+            raise ZehutError(
+                code=EXIT_CONFLICT,
+                message=(
+                    f"refusing to --force init with {len(current)} existing users in the registry"
+                ),
+                remediation="delete users individually with 'zehut user delete' first",
+            )
+
+    cfg = config.Config.default(domain=args.domain, backend=args.default_backend)
+    config.save(cfg)
+    users.init_registry()
+    emit_result(
+        {
+            "initialised": True,
+            "domain": cfg.domain,
+            "default_backend": cfg.default_backend,
+            "config_path": str(cfg_path),
+            "users_path": str(fs.users_file()),
+        },
+        json_mode=json_mode,
+    )
+    return 0
+```
+
+- [ ] **Step 3: Wire into the parser**
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py` — inside `_build_parser`, just before `return parser`, add:
+
+```python
+    # Noun groups + globals. Lazy-imported to keep parser construction cheap
+    # and to allow command modules to import CLI-layer symbols without
+    # circular imports.
+    from zehut.cli._commands import init as _init_cmd  # noqa: WPS433
+
+    sub = parser._subparsers._group_actions[0]  # type: ignore[attr-defined]
+    _init_cmd.register(sub)
+```
+
+Wait — that relies on a private attribute. Cleaner: capture the `subparsers` return value. Replace this block in `_build_parser`:
+
+```python
+    parser.add_subparsers(dest="command", parser_class=_ZehutArgumentParser)
+```
+
+with:
+
+```python
+    sub = parser.add_subparsers(dest="command", parser_class=_ZehutArgumentParser)
+
+    # Lazy imports avoid circulars (command modules import cli._output etc.).
+    from zehut.cli._commands import init as _init_cmd  # noqa: WPS433
+
+    _init_cmd.register(sub)
+```
+
+(Subsequent tasks will add more `_xxx_cmd.register(sub)` lines beneath this one.)
+
+- [ ] **Step 4: Run the init tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_init.py -v
+```
+
+- [ ] **Step 5: Run the full suite to confirm nothing regressed**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest -n auto -v
+```
+
+Expected: all tests pass; integration tests skip.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/init.py zehut/cli/__init__.py tests/unit/test_cmd_init.py
+git commit -m "feat(cmd): zehut init — idempotent bootstrap with --force guard"
+```
+
+---
+
+## Task 11: `zehut configuration` noun — `show`, `set`, `set-domain`
+
+**Goal:** Read and mutate the machine config. Sub-verbs wired under a single noun parser.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/configuration.py`
+- Modify: `/home/spark/git/zehut/zehut/cli/__init__.py` — register the noun.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_configuration.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_configuration.py`
+
+```python
+"""Unit tests for ``zehut configuration ...``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, config
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "old.example.com", "--default-backend", "logical"])
+    return config_dir, state_dir
+
+
+def test_configuration_show_json(tmp_zehut, capsys):
+    rc = cli.main(["--json", "configuration", "show"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["domain"] == "old.example.com"
+    assert payload["schema_version"] == 1
+
+
+def test_configuration_show_text(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "show"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "old.example.com" in cap.out
+
+
+def test_configuration_set_domain(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "set-domain", "new.example.com"])
+    assert rc == 0
+    assert config.load().domain == "new.example.com"
+
+
+def test_configuration_set_generic(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "set", "default_backend", "system"])
+    assert rc == 0
+    assert config.load().default_backend == "system"
+
+
+def test_configuration_set_rejects_unknown_key(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "set", "frobnicate", "no"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_STATE
+    assert "unknown" in cap.err.lower() or "settable" in cap.err.lower()
+
+
+def test_configuration_set_requires_root(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["configuration", "set-domain", "nope.com"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE
+```
+
+- [ ] **Step 2: Implement `zehut/cli/_commands/configuration.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/configuration.py`
+
+```python
+"""``zehut configuration`` — show and mutate ``/etc/zehut/config.toml``.
+
+Verbs:
+
+* ``show``          — render current config (text or JSON).
+* ``set``           — set a named key; delegates to :func:`zehut.config.set_key`.
+* ``set-domain``    — convenience shortcut for the most common mutation.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+
+from zehut import config, privilege
+from zehut.cli._errors import EXIT_PRIVILEGE, EXIT_STATE, ZehutError
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("configuration", help="Show or modify zehut configuration.")
+    sub = p.add_subparsers(dest="verb", required=True)
+
+    s_show = sub.add_parser("show", help="Render the current configuration.")
+    s_show.set_defaults(func=_cmd_show)
+
+    s_set = sub.add_parser("set", help="Set a configuration key.")
+    s_set.add_argument(
+        "key",
+        choices=("domain", "default_backend", "email_pattern", "email_collision"),
+    )
+    s_set.add_argument("value")
+    s_set.set_defaults(func=_cmd_set)
+
+    s_sd = sub.add_parser("set-domain", help="Shortcut for 'configuration set domain <value>'.")
+    s_sd.add_argument("domain")
+    s_sd.set_defaults(func=_cmd_set_domain)
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        cfg = config.load()
+    except config.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    payload = asdict(cfg)
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        lines = [
+            f"schema_version: {payload['schema_version']}",
+            f"domain:          {payload['domain']}",
+            f"default_backend: {payload['default_backend']}",
+            f"email_pattern:   {payload['email_pattern']}",
+            f"email_collision: {payload['email_collision']}",
+        ]
+        emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def _require_root(args: argparse.Namespace, argv: list[str]) -> None:
+    try:
+        privilege.require_root(action="modify /etc/zehut/config.toml", argv=argv)
+    except privilege.PrivilegeError as err:
+        raise ZehutError(
+            code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+        ) from err
+
+
+def _cmd_set(args: argparse.Namespace) -> int:
+    _require_root(args, ["configuration", "set", args.key, args.value])
+    try:
+        config.set_key(args.key, args.value)
+    except config.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE, message=str(err), remediation="zehut configuration show"
+        ) from err
+    return _cmd_show(args)
+
+
+def _cmd_set_domain(args: argparse.Namespace) -> int:
+    _require_root(args, ["configuration", "set-domain", args.domain])
+    try:
+        config.set_key("domain", args.domain)
+    except config.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE, message=str(err), remediation="zehut configuration show"
+        ) from err
+    return _cmd_show(args)
+```
+
+- [ ] **Step 3: Wire into the parser**
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py` — inside `_build_parser`, after the `_init_cmd.register(sub)` line, add:
+
+```python
+    from zehut.cli._commands import configuration as _configuration_cmd  # noqa: WPS433
+
+    _configuration_cmd.register(sub)
+```
+
+- [ ] **Step 4: Run the configuration tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_configuration.py -v
+```
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/configuration.py zehut/cli/__init__.py \
+        tests/unit/test_cmd_configuration.py
+git commit -m "feat(cmd): zehut configuration show/set/set-domain"
+```
+
+---
+
+## Task 12: `zehut user create`
+
+**Goal:** First of the `user` noun verbs. Decides backend (`--system` / `--logical` / configured default), enforces root if `--system`, calls `users.add` with the right backend instance.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/user.py` (starts with just `create`; later tasks extend it)
+- Modify: `/home/spark/git/zehut/zehut/cli/__init__.py` — register the noun.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_user_create.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_user_create.py`
+
+```python
+"""Unit tests for ``zehut user create``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    return config_dir, state_dir
+
+
+def test_create_logical_default(tmp_zehut, capsys):
+    rc = cli.main(["user", "create", "alice"])
+    assert rc == 0
+    recs = users.list_all()
+    assert len(recs) == 1
+    assert recs[0].name == "alice"
+    assert recs[0].backend == "logical"
+    assert recs[0].email.endswith("@agents.example.com")
+
+
+def test_create_with_explicit_system_flag(tmp_zehut, monkeypatch, capsys):
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=2001),
+    )
+    rc = cli.main(["user", "create", "bob", "--system", "--nick", "Bobby"])
+    assert rc == 0
+    rec = users.get("bob")
+    assert rec.backend == "system"
+    assert rec.nick == "Bobby"
+    assert rec.system_uid == 2001
+
+
+def test_create_system_without_root_errors(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["user", "create", "bob", "--system"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE
+    assert "sudo" in cap.err
+
+
+def test_create_duplicate_is_conflict(tmp_zehut, capsys):
+    cli.main(["user", "create", "alice"])
+    rc = cli.main(["user", "create", "alice"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_CONFLICT
+
+
+def test_create_honours_configured_default(tmp_zehut, monkeypatch, capsys):
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=2002),
+    )
+    # Flip default to system.
+    cli.main(["configuration", "set", "default_backend", "system"])
+    rc = cli.main(["user", "create", "carol"])
+    assert rc == 0
+    assert users.get("carol").backend == "system"
+
+
+def test_create_json_output(tmp_zehut, capsys):
+    rc = cli.main(["--json", "user", "create", "alice", "--about", "qa"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["name"] == "alice"
+    assert payload["about"] == "qa"
+    assert payload["backend"] == "logical"
+```
+
+- [ ] **Step 2: Implement `zehut/cli/_commands/user.py` (create only for now)**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/user.py`
+
+```python
+"""``zehut user`` noun group.
+
+Registers the ``user`` parser and its verbs. Each verb lives as a small
+handler function below. More verbs (list/show/set/switch/whoami/delete)
+are added in subsequent tasks.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut import config as cfg_mod
+from zehut import privilege, users
+from zehut.backend import LogicalBackend, SystemBackend
+from zehut.backend.base import Backend
+from zehut.cli._errors import EXIT_PRIVILEGE, EXIT_STATE, ZehutError
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("user", help="Manage zehut users.")
+    sub = p.add_subparsers(dest="verb", required=True)
+
+    _register_create(sub)
+
+
+def _register_create(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("create", help="Create a new zehut user.")
+    s.add_argument("name")
+    bg = s.add_mutually_exclusive_group()
+    bg.add_argument("--system", dest="backend_choice", action="store_const", const="system")
+    bg.add_argument("--logical", dest="backend_choice", action="store_const", const="logical")
+    s.add_argument("--nick", default=None)
+    s.add_argument("--about", default=None)
+    s.set_defaults(func=_cmd_create)
+
+
+def _resolve_backend(choice: str | None) -> tuple[str, Backend]:
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    backend_name = choice or cfg.default_backend
+    if backend_name == "system":
+        return "system", SystemBackend()
+    if backend_name == "logical":
+        return "logical", LogicalBackend()
+    raise ZehutError(
+        code=EXIT_STATE,
+        message=f"invalid backend {backend_name!r}",
+        remediation="configuration.default_backend must be 'system' or 'logical'",
+    )
+
+
+def _cmd_create(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    backend_name, backend = _resolve_backend(args.backend_choice)
+    if backend_name == "system":
+        try:
+            privilege.require_root(
+                action="create a system-backed user",
+                argv=["user", "create", args.name, "--system"],
+            )
+        except privilege.PrivilegeError as err:
+            raise ZehutError(
+                code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+            ) from err
+
+    rec = users.add(
+        name=args.name,
+        nick=args.nick,
+        about=args.about,
+        backend_name=backend_name,
+        backend=backend,
+    )
+    emit_result(users.record_to_dict(rec), json_mode=json_mode)
+    return 0
+```
+
+- [ ] **Step 3: Wire into the parser**
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py` — inside `_build_parser`, after the `_configuration_cmd.register(sub)` line, add:
+
+```python
+    from zehut.cli._commands import user as _user_cmd  # noqa: WPS433
+
+    _user_cmd.register(sub)
+```
+
+- [ ] **Step 4: Run the tests (expect pass)**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_user_create.py -v
+```
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/user.py zehut/cli/__init__.py tests/unit/test_cmd_user_create.py
+git commit -m "feat(cmd): zehut user create — backend resolution + root gate for --system"
+```
+
+---
+
+## Task 13: `zehut user list / show / set / delete`
+
+**Goal:** Remaining CRUD verbs on the `user` noun. Delete needs root iff the target is system-backed.
+
+**Files:**
+- Modify: `/home/spark/git/zehut/zehut/cli/_commands/user.py` — add four more verbs beneath `create`.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_user_crud.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_user_crud.py`
+
+```python
+"""Unit tests for ``zehut user list|show|set|delete``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut_with_alice(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    cli.main(["user", "create", "alice", "--nick", "Ali", "--about", "qa"])
+    return config_dir, state_dir
+
+
+def test_list_json(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["--json", "user", "list"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert isinstance(payload, list)
+    assert payload[0]["name"] == "alice"
+
+
+def test_list_text(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "list"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+    assert "logical" in cap.out
+
+
+def test_show_by_name(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "show", "alice"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+    assert "Ali" in cap.out
+
+
+def test_show_unknown_user(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "show", "ghost"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_set_nick_by_name(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "nick=Alicia"])
+    assert rc == 0
+    assert users.get("alice").nick == "Alicia"
+
+
+def test_set_multiple_fields(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "nick=A", "about=new"])
+    assert rc == 0
+    rec = users.get("alice")
+    assert rec.nick == "A"
+    assert rec.about == "new"
+
+
+def test_set_rejects_unknown_key(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "email=other@x.com"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_set_bad_assignment_syntax(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "nick Alicia"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_delete_logical_no_root_needed(tmp_zehut_with_alice, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["user", "delete", "alice"])
+    assert rc == 0
+    assert users.list_all() == []
+
+
+def test_delete_system_needs_root(tmp_path, monkeypatch, capsys):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "system"])
+
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=3001),
+    )
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "deprovision",
+        lambda self, *, name, system_user, keep_home: None,
+    )
+    cli.main(["user", "create", "bob", "--system"])
+
+    # Drop root for the delete.
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["user", "delete", "bob"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE
+```
+
+- [ ] **Step 2: Extend `zehut/cli/_commands/user.py` with the new verbs**
+
+Add the following inside the module (keep the existing `create` code intact). The full updated module file:
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/user.py`
+
+```python
+"""``zehut user`` noun group — create, list, show, set, delete, switch, whoami.
+
+switch/whoami are added in Task 14; this file after Task 13 carries the
+five CRUD verbs plus ``create``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+
+from zehut import config as cfg_mod
+from zehut import privilege, users
+from zehut.backend import LogicalBackend, SystemBackend
+from zehut.backend.base import Backend
+from zehut.cli._errors import (
+    EXIT_PRIVILEGE,
+    EXIT_STATE,
+    EXIT_USER_ERROR,
+    ZehutError,
+)
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("user", help="Manage zehut users.")
+    sub = p.add_subparsers(dest="verb", required=True)
+
+    _register_create(sub)
+    _register_list(sub)
+    _register_show(sub)
+    _register_set(sub)
+    _register_delete(sub)
+
+
+# --- create -------------------------------------------------------------------
+
+def _register_create(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("create", help="Create a new zehut user.")
+    s.add_argument("name")
+    bg = s.add_mutually_exclusive_group()
+    bg.add_argument("--system", dest="backend_choice", action="store_const", const="system")
+    bg.add_argument("--logical", dest="backend_choice", action="store_const", const="logical")
+    s.add_argument("--nick", default=None)
+    s.add_argument("--about", default=None)
+    s.set_defaults(func=_cmd_create)
+
+
+def _resolve_backend(choice: str | None) -> tuple[str, Backend]:
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    backend_name = choice or cfg.default_backend
+    if backend_name == "system":
+        return "system", SystemBackend()
+    if backend_name == "logical":
+        return "logical", LogicalBackend()
+    raise ZehutError(
+        code=EXIT_STATE,
+        message=f"invalid backend {backend_name!r}",
+        remediation="configuration.default_backend must be 'system' or 'logical'",
+    )
+
+
+def _cmd_create(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    backend_name, backend = _resolve_backend(args.backend_choice)
+    if backend_name == "system":
+        try:
+            privilege.require_root(
+                action="create a system-backed user",
+                argv=["user", "create", args.name, "--system"],
+            )
+        except privilege.PrivilegeError as err:
+            raise ZehutError(
+                code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+            ) from err
+
+    rec = users.add(
+        name=args.name,
+        nick=args.nick,
+        about=args.about,
+        backend_name=backend_name,
+        backend=backend,
+    )
+    emit_result(users.record_to_dict(rec), json_mode=json_mode)
+    return 0
+
+
+# --- list ---------------------------------------------------------------------
+
+def _register_list(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("list", help="List zehut users.")
+    s.set_defaults(func=_cmd_list)
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    recs = users.list_all()
+    if json_mode:
+        emit_result([users.record_to_dict(r) for r in recs], json_mode=True)
+        return 0
+    if not recs:
+        emit_result("(no users)", json_mode=False)
+        return 0
+    lines = [f"{'NAME':<20} {'BACKEND':<10} EMAIL"]
+    for rec in recs:
+        lines.append(f"{rec.name:<20} {rec.backend:<10} {rec.email}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+# --- show ---------------------------------------------------------------------
+
+def _register_show(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("show", help="Show a user's record.")
+    s.add_argument("name", nargs="?", default=None)
+    s.set_defaults(func=_cmd_show)
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    name = args.name or users.ambient_name()
+    if name is None:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message="no user name given and no ambient identity",
+            remediation="pass <name> or switch with 'zehut user switch <name>'",
+        )
+    rec = users.get(name)
+    if json_mode:
+        emit_result(users.record_to_dict(rec), json_mode=True)
+    else:
+        d = users.record_to_dict(rec)
+        lines = [f"{k}: {v}" for k, v in d.items()]
+        emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+# --- set ----------------------------------------------------------------------
+
+def _register_set(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("set", help="Mutate user metadata (nick, about).")
+    s.add_argument("name", nargs="?", default=None)
+    s.add_argument("assignments", nargs="+", help="key=value (repeatable)")
+    s.set_defaults(func=_cmd_set)
+
+
+def _parse_assignment(token: str) -> tuple[str, str]:
+    if "=" not in token:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=f"expected key=value, got {token!r}",
+            remediation="use the form 'nick=Ali'",
+        )
+    key, _, value = token.partition("=")
+    if not key:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=f"empty key in assignment {token!r}",
+            remediation="use the form 'nick=Ali'",
+        )
+    return key, value
+
+
+def _cmd_set(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    # If the first assignment arg looks like a name (no '='), ``name`` was
+    # consumed by argparse's nargs='?'. Otherwise all tokens are assignments
+    # and name comes from ambient.
+    name = args.name if args.name and "=" not in args.name else None
+    tokens: list[str] = list(args.assignments)
+    if args.name and "=" in args.name:
+        # argparse put a 'key=value' in 'name'; shift it back.
+        tokens.insert(0, args.name)
+        name = None
+    if name is None:
+        name = users.ambient_name()
+    if name is None:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message="no user name given and no ambient identity",
+            remediation="pass <name> as the first argument",
+        )
+    try:
+        privilege.require_root(
+            action="modify users.json", argv=["user", "set", name, *tokens]
+        )
+    except privilege.PrivilegeError as err:
+        raise ZehutError(
+            code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+        ) from err
+
+    fields: dict[str, str] = {}
+    for tok in tokens:
+        k, v = _parse_assignment(tok)
+        fields[k] = v
+    rec = users.update(name, **fields)
+    emit_result(users.record_to_dict(rec), json_mode=json_mode)
+    return 0
+
+
+# --- delete -------------------------------------------------------------------
+
+def _register_delete(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("delete", help="Remove a zehut user.")
+    s.add_argument("name")
+    s.add_argument(
+        "--keep-home",
+        action="store_true",
+        help="Don't pass -r to userdel (system-backed only).",
+    )
+    s.set_defaults(func=_cmd_delete)
+
+
+def _cmd_delete(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    rec = users.get(args.name)
+    if rec.backend == "system":
+        try:
+            privilege.require_root(
+                action="delete a system-backed user",
+                argv=["user", "delete", args.name]
+                + (["--keep-home"] if args.keep_home else []),
+            )
+        except privilege.PrivilegeError as err:
+            raise ZehutError(
+                code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+            ) from err
+        backend = SystemBackend()
+    else:
+        backend = LogicalBackend()
+    users.remove(args.name, backend=backend, keep_home=args.keep_home)
+    emit_result(
+        {"deleted": args.name, "backend": rec.backend}, json_mode=json_mode
+    )
+    return 0
+```
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_user_crud.py -v
+```
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest -n auto -v
+```
+
+Expected: all pass, integration skips.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/user.py tests/unit/test_cmd_user_crud.py
+git commit -m "feat(cmd): zehut user list/show/set/delete with ambient-name resolution"
+```
+
+---
+
+## Task 14: `zehut user switch` and `zehut user whoami` / `current`
+
+**Goal:** Switch execs `sudo -u <sysuser> -i` for system-backed, or prints an `export` line for logical. Whoami (aliased `current`) prints the ambient identity.
+
+**Files:**
+- Modify: `/home/spark/git/zehut/zehut/cli/_commands/user.py` — add `switch`, `whoami`, `current` alias.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_user_switch.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_user_switch.py`
+
+```python
+"""Unit tests for ``zehut user switch`` / ``whoami`` / ``current``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    return config_dir, state_dir
+
+
+def test_switch_logical_prints_export(tmp_zehut, capsys):
+    cli.main(["user", "create", "alice"])
+    rc = cli.main(["user", "switch", "alice"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert cap.out.strip() == 'export ZEHUT_IDENTITY=alice'
+
+
+def test_switch_unknown_user(tmp_zehut, capsys):
+    rc = cli.main(["user", "switch", "ghost"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_switch_system_execs_sudo(tmp_zehut, monkeypatch, capsys):
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=4001),
+    )
+    cli.main(["user", "create", "bob", "--system"])
+
+    recorded: list[list[str]] = []
+
+    def fake_execvp(prog, argv):
+        recorded.append([prog, *argv[1:]])
+        raise SystemExit(0)
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+    with pytest.raises(SystemExit) as se:
+        cli.main(["user", "switch", "bob"])
+    assert se.value.code == 0
+    assert recorded == [["sudo", "-u", "bob", "-i"]]
+
+
+def test_whoami_none_when_no_ambient(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.delenv("ZEHUT_IDENTITY", raising=False)
+    rc = cli.main(["user", "whoami"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_whoami_env_fallback(tmp_zehut, monkeypatch, capsys):
+    cli.main(["user", "create", "alice"])
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    rc = cli.main(["user", "whoami"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+
+
+def test_whoami_json(tmp_zehut, monkeypatch, capsys):
+    cli.main(["user", "create", "alice"])
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    rc = cli.main(["--json", "user", "whoami"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["name"] == "alice"
+
+
+def test_current_is_an_alias_for_whoami(tmp_zehut, monkeypatch, capsys):
+    cli.main(["user", "create", "alice"])
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    rc = cli.main(["user", "current"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+```
+
+- [ ] **Step 2: Extend `user.py` with switch/whoami/current**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/user.py` — add the following pieces.
+
+In the `register()` function, append after `_register_delete(sub)`:
+
+```python
+    _register_switch(sub)
+    _register_whoami(sub)
+```
+
+Append these handler blocks to the end of the file:
+
+```python
+# --- switch -------------------------------------------------------------------
+
+def _register_switch(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser(
+        "switch",
+        help="Switch identity: execs `sudo -u` for system; prints export for logical.",
+    )
+    s.add_argument("name")
+    s.set_defaults(func=_cmd_switch)
+
+
+def _cmd_switch(args: argparse.Namespace) -> int:
+    rec = users.get(args.name)
+    if rec.backend == "logical":
+        # Print an export line for ``eval $(zehut user switch <name>)``.
+        emit_result(f"export ZEHUT_IDENTITY={rec.name}", json_mode=False)
+        return 0
+    # System-backed: exec a login shell as the OS user. This replaces the
+    # current process on success.
+    import os
+
+    target = rec.system_user or rec.name
+    os.execvp("sudo", ["sudo", "-u", target, "-i"])
+    # If execvp returns, something broke.
+    raise ZehutError(  # pragma: no cover — execvp only returns on failure
+        code=EXIT_STATE,
+        message="execvp returned unexpectedly",
+        remediation="verify sudo is installed and on PATH",
+    )
+
+
+# --- whoami / current ---------------------------------------------------------
+
+def _register_whoami(sub: "argparse._SubParsersAction") -> None:
+    for verb in ("whoami", "current"):
+        s = sub.add_parser(verb, help="Print the ambient zehut identity.")
+        s.set_defaults(func=_cmd_whoami)
+
+
+def _cmd_whoami(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    name = users.ambient_name()
+    if name is None:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message="no current zehut user",
+            remediation="run 'zehut user switch <name>' or 'zehut user create <name>'",
+        )
+    rec = users.get(name)
+    if json_mode:
+        emit_result(users.record_to_dict(rec), json_mode=True)
+    else:
+        emit_result(
+            f"{rec.name} ({rec.backend}, email={rec.email})", json_mode=False
+        )
+    return 0
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_user_switch.py -v
+```
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/user.py tests/unit/test_cmd_user_switch.py
+git commit -m "feat(cmd): zehut user switch/whoami/current — sudo exec + ambient + env fallback"
+```
+
+---
+
+## Task 15: `zehut doctor`
+
+**Goal:** Eight health checks from spec §6.3, each returning PASS/FAIL/WARN + remediation. Read-only in v1.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/doctor.py`
+- Modify: `/home/spark/git/zehut/zehut/cli/__init__.py` — register.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_doctor.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_doctor.py`
+
+```python
+"""Unit tests for ``zehut doctor``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, fs
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    return config_dir, state_dir
+
+
+def test_doctor_fails_when_uninitialised(tmp_zehut, capsys):
+    rc = cli.main(["--json", "doctor"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    # Expect a FAIL on config-exists check.
+    check_names = {c["name"]: c["status"] for c in payload["checks"]}
+    assert check_names["config_exists"] == "FAIL"
+    # doctor itself exits 0 — it's a report.
+    assert rc == 0
+
+
+def test_doctor_all_pass_after_init(tmp_zehut, capsys):
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    rc = cli.main(["--json", "doctor"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    statuses = {c["status"] for c in payload["checks"]}
+    assert "FAIL" not in statuses
+    assert rc == 0
+
+
+def test_doctor_reports_drift_when_system_entry_has_unknown_uid(
+    tmp_zehut, monkeypatch, capsys
+):
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=5001),
+    )
+    cli.main(["user", "create", "bob", "--system"])
+
+    # Now pretend bob is gone from /etc/passwd.
+    import pwd as _pwd
+
+    def _getpwnam(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr(_pwd, "getpwnam", _getpwnam)
+    rc = cli.main(["--json", "doctor"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    names = {c["name"]: c["status"] for c in payload["checks"]}
+    assert names["system_users_resolve"] == "FAIL"
+```
+
+- [ ] **Step 2: Implement `zehut/cli/_commands/doctor.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/doctor.py`
+
+```python
+"""``zehut doctor`` — read-only system health report.
+
+Eight checks from spec §6.3. Each check returns a dict with ``name``,
+``status`` (``PASS`` | ``FAIL`` | ``WARN``), ``detail``, and
+``remediation``. The command itself always exits 0: it's a report, not a
+gate. Callers who want a non-zero exit on any FAIL should inspect the
+JSON output (``--json``) and react accordingly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pwd
+import re
+import shutil
+from dataclasses import dataclass
+
+from zehut import config as cfg_mod
+from zehut import fs, users
+from zehut.cli._output import emit_result
+
+_DOMAIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    detail: str
+    remediation: str
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("doctor", help="Read-only health check.")
+    p.set_defaults(func=run)
+
+
+def _check_config_exists() -> Check:
+    path = fs.config_file()
+    if path.exists():
+        return Check("config_exists", "PASS", str(path), "")
+    return Check(
+        "config_exists",
+        "FAIL",
+        f"{path} missing",
+        "run: sudo zehut init --domain <d> --default-backend <backend>",
+    )
+
+
+def _check_users_exists() -> Check:
+    path = fs.users_file()
+    if path.exists():
+        return Check("users_exists", "PASS", str(path), "")
+    return Check(
+        "users_exists",
+        "FAIL",
+        f"{path} missing",
+        "run: sudo zehut init ... (or 'zehut init --force' to rebuild)",
+    )
+
+
+def _check_file_modes() -> Check:
+    cfg_path = fs.config_file()
+    users_path = fs.users_file()
+    problems: list[str] = []
+    for p in (cfg_path, users_path):
+        if not p.exists():
+            continue
+        mode = p.stat().st_mode & 0o777
+        if mode != 0o644:
+            problems.append(f"{p} mode={oct(mode)} (expected 0o644)")
+    if problems:
+        return Check(
+            "file_modes",
+            "WARN",
+            "; ".join(problems),
+            "fix with: sudo chmod 644 <path>",
+        )
+    return Check("file_modes", "PASS", "0o644", "")
+
+
+def _check_useradd_on_path() -> Check:
+    # Only relevant if any system-backed users exist.
+    try:
+        has_system = any(r.backend == "system" for r in users.list_all())
+    except Exception:
+        has_system = False
+    if not has_system:
+        return Check("useradd_available", "PASS", "not required", "")
+    for binary in ("useradd", "userdel", "id"):
+        if shutil.which(binary) is None:
+            return Check(
+                "useradd_available",
+                "FAIL",
+                f"{binary} not on PATH",
+                "install the 'shadow' / 'shadow-utils' package for your distro",
+            )
+    return Check("useradd_available", "PASS", "useradd, userdel, id on PATH", "")
+
+
+def _check_system_users_resolve() -> Check:
+    try:
+        recs = users.list_all()
+    except Exception as err:
+        return Check(
+            "system_users_resolve", "FAIL", str(err), "inspect /var/lib/zehut/users.json"
+        )
+    problems: list[str] = []
+    for rec in recs:
+        if rec.backend != "system":
+            continue
+        target = rec.system_user or rec.name
+        try:
+            entry = pwd.getpwnam(target)
+        except KeyError:
+            problems.append(f"{rec.name}: OS user {target!r} missing")
+            continue
+        if entry.pw_uid != rec.system_uid:
+            problems.append(
+                f"{rec.name}: uid drift (registry={rec.system_uid}, os={entry.pw_uid})"
+            )
+    if problems:
+        return Check(
+            "system_users_resolve",
+            "FAIL",
+            "; ".join(problems),
+            "reconcile manually in v1; 'zehut doctor --adopt' is v2",
+        )
+    return Check("system_users_resolve", "PASS", f"{len(recs)} users consistent", "")
+
+
+def _check_logical_name_vs_os() -> Check:
+    try:
+        recs = users.list_all()
+    except Exception:
+        return Check("logical_names_free", "PASS", "registry unreadable; skipped", "")
+    collisions: list[str] = []
+    for rec in recs:
+        if rec.backend != "logical":
+            continue
+        try:
+            pwd.getpwnam(rec.name)
+            collisions.append(rec.name)
+        except KeyError:
+            continue
+    if collisions:
+        return Check(
+            "logical_names_free",
+            "WARN",
+            f"logical names also exist as OS users: {collisions}",
+            "rename (v2) or delete the colliding logical user",
+        )
+    return Check("logical_names_free", "PASS", "no collisions", "")
+
+
+def _check_ambient_resolution() -> Check:
+    try:
+        os_name = pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        return Check("ambient_resolution", "PASS", "no OS user for euid", "")
+    try:
+        recs = users.list_all()
+    except Exception:
+        return Check("ambient_resolution", "PASS", "registry unreadable; skipped", "")
+    for rec in recs:
+        if rec.backend == "system" and rec.system_user == os_name:
+            return Check(
+                "ambient_resolution",
+                "PASS",
+                f"current OS user {os_name!r} resolves to zehut {rec.name!r}",
+                "",
+            )
+    return Check(
+        "ambient_resolution", "PASS", f"current OS user {os_name!r} is not zehut-managed", ""
+    )
+
+
+def _check_domain_format() -> Check:
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        return Check("domain_format", "FAIL", str(err), "run: sudo zehut init ...")
+    if _DOMAIN_RE.match(cfg.domain):
+        return Check("domain_format", "PASS", cfg.domain, "")
+    return Check(
+        "domain_format",
+        "FAIL",
+        f"{cfg.domain!r} not a valid-looking domain",
+        "fix with: sudo zehut configuration set-domain <domain>",
+    )
+
+
+_CHECKS = (
+    _check_config_exists,
+    _check_users_exists,
+    _check_file_modes,
+    _check_useradd_on_path,
+    _check_system_users_resolve,
+    _check_logical_name_vs_os,
+    _check_ambient_resolution,
+    _check_domain_format,
+)
+
+
+def run(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    results = [c() for c in _CHECKS]
+    if json_mode:
+        emit_result(
+            {
+                "checks": [
+                    {
+                        "name": r.name,
+                        "status": r.status,
+                        "detail": r.detail,
+                        "remediation": r.remediation,
+                    }
+                    for r in results
+                ]
+            },
+            json_mode=True,
+        )
+        return 0
+
+    lines = []
+    for r in results:
+        marker = {"PASS": "✓", "WARN": "!", "FAIL": "✗"}.get(r.status, "?")
+        line = f"{marker} [{r.status}] {r.name}: {r.detail}"
+        lines.append(line)
+        if r.remediation:
+            lines.append(f"    hint: {r.remediation}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+```
+
+- [ ] **Step 3: Wire into the parser**
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py` — after `_user_cmd.register(sub)` add:
+
+```python
+    from zehut.cli._commands import doctor as _doctor_cmd  # noqa: WPS433
+
+    _doctor_cmd.register(sub)
+```
+
+- [ ] **Step 4: Run tests + full suite**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_doctor.py -v
+uv run pytest -n auto
+```
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/doctor.py zehut/cli/__init__.py tests/unit/test_cmd_doctor.py
+git commit -m "feat(cmd): zehut doctor — eight read-only health checks"
+```
+
+---
+
+## Task 16: Agent-first globals — `learn`, `overview`, `explain`
+
+**Goal:** Three commands that make zehut self-describing to an AI agent, following the afi-cli convention.
+
+- `learn` — emit a single skill-style markdown document an agent can drop into its own skills directory.
+- `overview` — machine-readable snapshot: config + all users + their emails + backing types.
+- `explain <topic>` — short prose explanation for a command or concept.
+
+**Files:**
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/learn.py`
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/overview.py`
+- Create: `/home/spark/git/zehut/zehut/cli/_commands/explain.py`
+- Modify: `/home/spark/git/zehut/zehut/cli/__init__.py` — register all three.
+- Create: `/home/spark/git/zehut/tests/unit/test_cmd_globals.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `/home/spark/git/zehut/tests/unit/test_cmd_globals.py`
+
+```python
+"""Unit tests for the agent-first globals (learn, overview, explain)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    cli.main(["user", "create", "alice", "--nick", "Ali"])
+    return config_dir, state_dir
+
+
+def test_learn_emits_markdown_with_frontmatter(tmp_zehut, capsys):
+    rc = cli.main(["learn"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert cap.out.startswith("---\n")
+    assert "name:" in cap.out
+    assert "zehut user" in cap.out
+
+
+def test_overview_json_shape(tmp_zehut, capsys):
+    rc = cli.main(["--json", "overview"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert "config" in payload
+    assert "users" in payload
+    assert payload["config"]["domain"] == "agents.example.com"
+    assert payload["users"][0]["name"] == "alice"
+
+
+def test_overview_text(tmp_zehut, capsys):
+    rc = cli.main(["overview"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "agents.example.com" in cap.out
+    assert "alice" in cap.out
+
+
+def test_explain_known_topic(tmp_zehut, capsys):
+    rc = cli.main(["explain", "user"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "user" in cap.out.lower()
+
+
+def test_explain_unknown_topic(tmp_zehut, capsys):
+    rc = cli.main(["explain", "frobnicate"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+```
+
+- [ ] **Step 2: Implement `zehut/cli/_commands/learn.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/learn.py`
+
+```python
+"""``zehut learn`` — emit a single agent-consumable skill markdown doc.
+
+The output is copy-pasteable into an agent's skills directory (or piped
+into one by an SDK). Keep it terse: the agent reads it once, then reads
+``zehut --help`` / ``zehut explain <topic>`` for detail.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut.cli._output import emit_result
+
+_SKILL_BODY = """\
+---
+name: zehut
+description: Drive the zehut CLI to manage local machine identities (system-backed and logical) and their emails.
+---
+
+# Using zehut
+
+zehut is the identity layer. Every command is ``zehut <noun> <verb>`` or a
+top-level global.
+
+## Core commands
+
+- ``zehut init --domain <d> --default-backend system|logical`` — one-time bootstrap. Needs sudo.
+- ``zehut user create <name> [--system|--logical] [--nick ..] [--about ..]`` — create a user.
+- ``zehut user list [--json]``, ``zehut user show [<name>]`` — read.
+- ``zehut user set [<name>] nick=.. about=..`` — mutate metadata (sudo).
+- ``zehut user switch <name>`` — logical: prints ``export ZEHUT_IDENTITY=…`` (use with ``eval``).  System: execs ``sudo -u <user> -i``.
+- ``zehut user whoami`` (aliased ``current``) — ambient identity.
+- ``zehut user delete <name> [--keep-home]`` — remove.
+- ``zehut configuration show|set|set-domain`` — config ops (sudo for writes).
+- ``zehut doctor`` — read-only health checks.
+- ``zehut overview`` — machine-readable snapshot.
+- ``zehut explain <topic>`` — prose explanation.
+
+## Conventions
+
+- Every command accepts ``--json`` at the top level: ``zehut --json ...``.
+- Errors: stderr ``error: <msg>`` + ``hint: <remediation>``, or a JSON
+  object ``{"error", "code", "hint"}`` in ``--json`` mode.
+- Ambient identity: if your process runs under a zehut-created OS user,
+  ``user show`` / ``user set`` default to that user with no arg.
+"""
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("learn", help="Emit an agent-consumable skill document.")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    emit_result(_SKILL_BODY, json_mode=False)
+    return 0
+```
+
+- [ ] **Step 3: Implement `zehut/cli/_commands/overview.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/overview.py`
+
+```python
+"""``zehut overview`` — full state snapshot (config + users)."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+
+from zehut import config as cfg_mod
+from zehut import users
+from zehut.cli._errors import EXIT_STATE, ZehutError
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("overview", help="Machine-readable snapshot of config + users.")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    recs = users.list_all()
+    payload = {
+        "config": asdict(cfg),
+        "users": [users.record_to_dict(r) for r in recs],
+    }
+    if json_mode:
+        emit_result(payload, json_mode=True)
+        return 0
+    lines = [
+        "CONFIG",
+        f"  domain:          {cfg.domain}",
+        f"  default_backend: {cfg.default_backend}",
+        f"  email_pattern:   {cfg.email_pattern}",
+        "",
+        f"USERS ({len(recs)})",
+    ]
+    for rec in recs:
+        lines.append(
+            f"  - {rec.name} [{rec.backend}] email={rec.email} nick={rec.nick} about={rec.about}"
+        )
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+```
+
+- [ ] **Step 4: Implement `zehut/cli/_commands/explain.py`**
+
+Path: `/home/spark/git/zehut/zehut/cli/_commands/explain.py`
+
+```python
+"""``zehut explain <topic>`` — prose explanation of a command or concept."""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut.cli._errors import EXIT_USER_ERROR, ZehutError
+from zehut.cli._output import emit_result
+
+_TOPICS: dict[str, str] = {
+    "zehut": (
+        "zehut is the agents-first identity layer. It manages machine-local users "
+        "(system-backed via useradd, or logical/metadata-only) and assigns each one "
+        "a deterministic email from a configured domain. Secrets are NOT in this "
+        "package — a separate CLI consumes the users.json registry for that."
+    ),
+    "user": (
+        "A zehut user is an identity with a stable ULID, a human name, optional "
+        "nick/about metadata, an auto-generated email, and a backing: 'system' "
+        "(real OS user) or 'logical' (metadata only)."
+    ),
+    "user create": (
+        "Creates a new user. With --system, zehut runs useradd to provision a real "
+        "OS account (requires sudo). With --logical, it records metadata only. "
+        "Without either flag, uses configuration.default_backend."
+    ),
+    "user switch": (
+        "Switches identity. For system-backed users, execs `sudo -u <user> -i` "
+        "(which replaces your shell). For logical users, prints "
+        "`export ZEHUT_IDENTITY=<name>` — pair with `eval $(zehut user switch <name>)`."
+    ),
+    "user whoami": (
+        "Prints the current ambient identity. Resolved in order: (1) OS user if "
+        "it matches a system-backed zehut user; (2) $ZEHUT_IDENTITY env var for "
+        "logical users; (3) nothing (exits non-zero)."
+    ),
+    "configuration": (
+        "Machine-wide config lives in /etc/zehut/config.toml. Keys: domain (email "
+        "domain), default_backend (system|logical), email_pattern (tokens: "
+        "{name}, {nick}, {id-short}, fallback syntax {nick|name}), "
+        "email_collision (suffix)."
+    ),
+    "doctor": (
+        "Read-only health report. Eight checks: config exists, registry exists, "
+        "file modes, useradd on PATH, system users resolve, logical names free, "
+        "ambient resolution, domain format. Always exits 0 — inspect --json output."
+    ),
+    "init": (
+        "Bootstraps /etc/zehut/config.toml and /var/lib/zehut/users.json. "
+        "Idempotent: safe to re-run. Use --force to overwrite config (never wipes "
+        "a non-empty user registry)."
+    ),
+}
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("explain", help="Explain a zehut command or concept.")
+    p.add_argument("topic", help="e.g. 'user create', 'doctor', 'zehut'")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    key = args.topic.strip()
+    if key not in _TOPICS:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=f"no explanation for {args.topic!r}",
+            remediation=f"known topics: {', '.join(sorted(_TOPICS))}",
+        )
+    from zehut.cli._output import emit_result
+
+    emit_result(_TOPICS[key], json_mode=False)
+    return 0
+```
+
+- [ ] **Step 5: Wire into the parser**
+
+Path: `/home/spark/git/zehut/zehut/cli/__init__.py` — after `_doctor_cmd.register(sub)`:
+
+```python
+    from zehut.cli._commands import explain as _explain_cmd  # noqa: WPS433
+    from zehut.cli._commands import learn as _learn_cmd  # noqa: WPS433
+    from zehut.cli._commands import overview as _overview_cmd  # noqa: WPS433
+
+    _learn_cmd.register(sub)
+    _overview_cmd.register(sub)
+    _explain_cmd.register(sub)
+```
+
+- [ ] **Step 6: Run tests + full suite**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/unit/test_cmd_globals.py -v
+uv run pytest -n auto
+```
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/cli/_commands/learn.py zehut/cli/_commands/overview.py \
+        zehut/cli/_commands/explain.py zehut/cli/__init__.py \
+        tests/unit/test_cmd_globals.py
+git commit -m "feat(cmd): agent-first globals — learn, overview, explain"
+```
+
+---
+
+## Task 17: CI workflows + vendored version-bump skill
+
+**Goal:** `tests.yml`, `publish.yml`, `security-checks.yml` plus the vendored `.claude/skills/version-bump/` from afi-cli. `version-check` job enforces mandatory bumps.
+
+**Files:**
+- Create: `/home/spark/git/zehut/.github/workflows/tests.yml`
+- Create: `/home/spark/git/zehut/.github/workflows/publish.yml`
+- Create: `/home/spark/git/zehut/.github/workflows/security-checks.yml`
+- Create: `/home/spark/git/zehut/.github/workflows/Dockerfile.integration`
+- Copy: `/home/spark/git/afi-cli/.claude/skills/version-bump/` → `/home/spark/git/zehut/.claude/skills/version-bump/`
+
+- [ ] **Step 1: Vendor the version-bump skill**
+
+```bash
+cd /home/spark/git/zehut
+mkdir -p .claude/skills
+cp -r /home/spark/git/afi-cli/.claude/skills/version-bump .claude/skills/
+```
+
+Verify `python3 .claude/skills/version-bump/scripts/bump.py --help` (or the skill's equivalent) runs without errors. If the script has afi-specific hardcoded paths, adjust them to reference this repo's `pyproject.toml` — most likely it already reads from `pyproject.toml` at CWD and is portable. Verify by reading `scripts/bump.py` and grepping for `afi`:
+
+```bash
+cd /home/spark/git/zehut
+grep -n "afi" .claude/skills/version-bump/scripts/bump.py || echo "portable as-is"
+```
+
+If hits come back, edit them to be package-agnostic (use `pyproject.toml` at CWD, no hardcoded package name).
+
+- [ ] **Step 2: Write `tests.yml`**
+
+Path: `/home/spark/git/zehut/.github/workflows/tests.yml`
+
+```yaml
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run black --check zehut tests
+      - run: uv run isort --check-only zehut tests
+      - run: uv run flake8 --config=.flake8 zehut tests
+      - run: uv run bandit -r zehut -c pyproject.toml
+
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run pytest -n auto --cov=zehut --cov-report=term -m "not integration"
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build integration image
+        run: docker build -t zehut-int -f .github/workflows/Dockerfile.integration .
+      - name: Run integration tests inside container
+        run: docker run --rm -e ZEHUT_DOCKER=1 zehut-int uv run pytest tests/integration -v -m integration
+
+  version-check:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Compare versions
+        run: |
+          set -euo pipefail
+          head_version=$(grep -E '^version = ' pyproject.toml | head -1 | awk -F'"' '{print $2}')
+          git fetch origin main --depth=1
+          base_version=$(git show origin/main:pyproject.toml | grep -E '^version = ' | head -1 | awk -F'"' '{print $2}')
+          echo "base=$base_version head=$head_version"
+          if [ "$base_version" = "$head_version" ]; then
+            echo "ERROR: version unchanged. Run the version-bump skill." >&2
+            exit 1
+          fi
+```
+
+- [ ] **Step 3: Write `publish.yml`**
+
+Path: `/home/spark/git/zehut/.github/workflows/publish.yml`
+
+```yaml
+name: publish
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  id-token: write  # for Trusted Publishing (OIDC)
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv build
+      - id: v
+        run: echo "version=$(grep -E '^version = ' pyproject.toml | head -1 | awk -F'\"' '{print $2}')" >> "$GITHUB_OUTPUT"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  testpypi:
+    needs: build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/zehut/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pypi:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/zehut/
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+- [ ] **Step 4: Write `security-checks.yml`**
+
+Path: `/home/spark/git/zehut/.github/workflows/security-checks.yml`
+
+```yaml
+name: security
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"  # weekly, Monday 05:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run bandit -r zehut -c pyproject.toml
+
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - run: uv sync
+      - run: uv run pip install pip-audit
+      - run: uv run pip-audit
+
+  trivy-fs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL
+```
+
+- [ ] **Step 5: Write the integration Dockerfile**
+
+Path: `/home/spark/git/zehut/.github/workflows/Dockerfile.integration`
+
+```dockerfile
+# Disposable image for running tests that require real useradd/userdel.
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        sudo passwd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /src
+COPY pyproject.toml uv.lock ./
+COPY zehut ./zehut
+COPY tests ./tests
+COPY .flake8 ./
+
+RUN uv sync
+
+# Default runs unit + integration. Override at `docker run` time.
+CMD ["uv", "run", "pytest", "-v"]
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add .github .claude
+git commit -m "ci: add tests/publish/security workflows + vendored version-bump skill"
+```
+
+Note: you cannot locally verify GitHub Actions — trust the YAML syntax by lint-reading. The PR that merges this series will surface any issues on the first Actions run.
+
+---
+
+## Task 18: `test_self_verify.py` + integration marker plumbing
+
+**Goal:** One end-to-end script that spins up a tmpdir-rooted zehut state, runs a full create-list-delete cycle, and asserts `doctor --json` comes back clean. Complements the per-module unit tests with a smoke-level dogfood.
+
+**Files:**
+- Create: `/home/spark/git/zehut/tests/test_self_verify.py`
+
+- [ ] **Step 1: Write the test**
+
+Path: `/home/spark/git/zehut/tests/test_self_verify.py`
+
+```python
+"""End-to-end self-verify: a full lifecycle against a tmpdir-rooted zehut.
+
+Runs the CLI as a subprocess so argv parsing, env resolution, and exit
+codes are exercised the way a user or agent would invoke them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def zehut_env(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    config_dir.mkdir()
+    state_dir.mkdir()
+    env = os.environ.copy()
+    env["ZEHUT_CONFIG_DIR"] = str(config_dir)
+    env["ZEHUT_STATE_DIR"] = str(state_dir)
+    env.pop("ZEHUT_IDENTITY", None)
+    return env
+
+
+def _run(env: dict, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "zehut", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_full_logical_lifecycle(zehut_env, monkeypatch):
+    # Fake root so privilege checks pass.
+    # The subprocess inherits env; override geteuid via a PYTHONSTARTUP trick
+    # is overkill. Instead: self-verify uses the LOGICAL backend only, so
+    # privilege checks for 'user create' are not triggered. 'init' and
+    # 'user set' require root though — we bypass by patching pwd... no,
+    # simpler: set ZEHUT_SELF_VERIFY_SKIP_PRIV to a marker and add one tiny
+    # bypass in privilege.py. BUT the plan promises no runtime deps changes
+    # post-Task 3. So instead, run the subprocess as a child under our
+    # current euid and expect it to detect we're not root — then we'll skip
+    # tests that require root here. init needs root, so the whole suite
+    # cannot run without a patch. Best solution: expose a PRIV_TEST env
+    # hook in privilege.py. We'll add it here.
+    # NOTE: If privilege.py already has ZEHUT_ASSUME_ROOT handling, use it.
+    env = dict(zehut_env)
+    env["ZEHUT_ASSUME_ROOT"] = "1"
+
+    rc = _run(env, "init", "--domain", "agents.example.com", "--default-backend", "logical")
+    assert rc.returncode == 0, rc.stderr
+
+    rc = _run(env, "user", "create", "alice", "--nick", "Ali")
+    assert rc.returncode == 0, rc.stderr
+
+    rc = _run(env, "--json", "user", "list")
+    assert rc.returncode == 0
+    payload = json.loads(rc.stdout.splitlines()[-1])
+    assert payload[0]["name"] == "alice"
+
+    rc = _run(env, "--json", "doctor")
+    assert rc.returncode == 0
+    doctor_payload = json.loads(rc.stdout.splitlines()[-1])
+    statuses = {c["status"] for c in doctor_payload["checks"]}
+    assert "FAIL" not in statuses
+
+    rc = _run(env, "user", "delete", "alice")
+    assert rc.returncode == 0
+```
+
+- [ ] **Step 2: Add the `ZEHUT_ASSUME_ROOT` bypass**
+
+Path: `/home/spark/git/zehut/zehut/privilege.py` — modify `is_root`:
+
+```python
+def is_root() -> bool:
+    if os.environ.get("ZEHUT_ASSUME_ROOT") == "1":
+        return True
+    return os.geteuid() == 0
+```
+
+Document this in `docs/testing.md` (Task 19) as a test-only affordance.
+
+- [ ] **Step 3: Add a matching unit test for the bypass**
+
+Path: `/home/spark/git/zehut/tests/unit/test_privilege.py` — append:
+
+```python
+def test_assume_root_env_bypasses_real_geteuid(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 1000)
+    monkeypatch.setenv("ZEHUT_ASSUME_ROOT", "1")
+    assert privilege.is_root() is True
+```
+
+- [ ] **Step 4: Run self-verify + full suite**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest tests/test_self_verify.py -v
+uv run pytest -n auto
+```
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /home/spark/git/zehut
+uv run black zehut tests && uv run isort zehut tests && uv run flake8 --config=.flake8 zehut tests
+git add zehut/privilege.py tests/test_self_verify.py tests/unit/test_privilege.py
+git commit -m "test: add end-to-end self-verify lifecycle + ZEHUT_ASSUME_ROOT bypass"
+```
+
+---
+
+## Task 19: Docs — threat-model, identity-model, testing, CLAUDE.md, README
+
+**Goal:** Ship the documents referenced throughout the spec and CI. No code changes. Every doc is short and focused (mirrors afi-cli's `docs/` style).
+
+**Files:**
+- Create: `/home/spark/git/zehut/docs/threat-model.md`
+- Create: `/home/spark/git/zehut/docs/identity-model.md`
+- Create: `/home/spark/git/zehut/docs/testing.md`
+- Modify: `/home/spark/git/zehut/CLAUDE.md`
+- Modify: `/home/spark/git/zehut/README.md`
+
+- [ ] **Step 1: Write `docs/threat-model.md`**
+
+Path: `/home/spark/git/zehut/docs/threat-model.md`
+
+```markdown
+# zehut threat model (v1)
+
+## Trust boundary
+
+The host OS and its sudoers policy. zehut is a privileged CLI: any caller
+who can become root can do everything zehut can do anyway. zehut's job is
+to be a well-behaved privileged caller — not to enforce authorisation
+above the OS layer.
+
+## Adversary model (v1)
+
+Single-admin trusted host. Non-root local users MUST NOT be able to:
+
+1. Escalate privileges via a zehut invocation.
+2. Tamper with `/var/lib/zehut/users.json` or `/etc/zehut/config.toml`.
+3. Impersonate another zehut user through ambient resolution.
+
+Multi-tenant hosts, network services, and cloud identity backends are
+out of scope for v1.
+
+## Risk surfaces
+
+### 1. Privileged subprocess invocation (`useradd` / `userdel`)
+
+- `PATH` is pinned to `/usr/sbin:/usr/bin` on every `subprocess.run` call
+  in `zehut/backend/system.py`.
+- `LC_ALL=C` is set so error parsing is stable across locales.
+- Names are validated against `^[a-z_][a-z0-9_-]{0,31}$` before they
+  reach the subprocess — rejects shell metacharacters at the zehut
+  layer.
+- Flags are hard-coded; user input never lands in a flag position.
+
+### 2. TOCTOU between `geteuid()` and subprocess
+
+- `privilege.require_root()` is called as late as possible (inside the
+  handler, before any state mutation). A successful check is immediately
+  followed by the privileged subprocess; there is no user-controlled
+  I/O in between that could trigger a suid change.
+- Python processes cannot drop/gain privileges between calls without
+  `setuid`; zehut never calls `setuid`.
+
+### 3. Registry file tampering
+
+- `users.json` and `config.toml` live in root-owned directories with
+  mode 0o644. Non-root users can read (needed for `whoami` / `list`)
+  but cannot write.
+- `doctor` validates modes and ownership; any drift is reported as
+  `WARN`.
+- Writers hold `fcntl.LOCK_EX` on `.lock` and use
+  write-temp→fsync→rename. A concurrent reader holding `LOCK_SH`
+  observes the old file until rename completes.
+
+### 4. Email domain takeover
+
+- Out of zehut's control. The configured domain's DNS/MX posture is the
+  operator's responsibility. `doctor` only validates syntactic
+  well-formedness.
+- Documented here so operators understand the boundary.
+
+### 5. Unprotected state during `init`
+
+- `init` creates `config.toml` and `users.json` via
+  `fs.atomic_write_text(..., mode=0o644)`, which uses `mkstemp` with
+  default 0o600 perms before the explicit `chmod 0o644`. There is no
+  window in which either file is world-readable without being also
+  world-unwritable.
+
+## Known non-goals (v2+)
+
+- Caller authentication beyond sudo.
+- Audit log of mutations.
+- Remote/cloud backends.
+- Multi-machine federation.
+
+These are tracked in the design spec's "v2 candidates" and will each get
+a threat-model update when added.
+```
+
+- [ ] **Step 2: Write `docs/identity-model.md`**
+
+Path: `/home/spark/git/zehut/docs/identity-model.md`
+
+```markdown
+# zehut identity model
+
+A zehut identity ("user" in v1) is:
+
+- a stable **ULID `id`** — immutable, safe to reference in audit trails
+  and future rename operations.
+- a **`name`** — the primary handle users type. For system-backed users
+  this MUST equal the OS username.
+- optional **`nick`** and **`about`** metadata.
+- an auto-generated **`email`** derived from `configuration.email_pattern`
+  + `configuration.domain` at create-time, collision-suffixed if needed.
+  Immutable post-create in v1.
+- a **backing**: `system` or `logical`.
+
+## Backings
+
+### System-backed
+
+- A real local OS account (`useradd` at create, `userdel` at delete).
+- Home directory created by default (`useradd -m`); skipped deletion
+  with `zehut user delete --keep-home`.
+- Primary group matches the username (`useradd -U`).
+- Default shell `/bin/bash`.
+- Provisioning requires root — the CLI surfaces a `sudo zehut …`
+  remediation when called unprivileged.
+
+### Logical
+
+- Metadata only. No OS account. No sudo required for create/delete.
+- "Current identity" cannot be resolved ambient-style (no OS user to
+  match against); falls back to `$ZEHUT_IDENTITY` env var.
+- Useful when you need a zehut identity for accounting or email
+  allocation but don't want an OS account to manage.
+
+## Ambient resolution
+
+`zehut user whoami` (aliased `current`), and the optional `<name>`
+argument of `zehut user show` / `set`, resolve the current identity in
+this order:
+
+1. **OS user match**: `pwd.getpwuid(os.geteuid()).pw_name` is looked up
+   against system-backed registry entries. If found, that is the
+   identity. Zero-config for agents launched under a zehut-provisioned
+   user (Claude Agent SDK, cron, systemd services, `sudo -u …`).
+2. **`$ZEHUT_IDENTITY`**: set by `eval $(zehut user switch <logical>)`
+   inside a shell, or exported manually.
+3. **None**: commands that require a current identity exit with
+   `EXIT_USER_ERROR` and a remediation hint.
+
+## The registry as a stable contract
+
+`/var/lib/zehut/users.json` is consumed by a separate (forthcoming)
+secrets CLI. Its `schema_version = 1` shape is stable; any breaking
+change bumps the version and ships a `zehut migrate` verb.
+
+Downstream consumers should:
+
+- Read the file under `fs.shared_lock(/var/lib/zehut/.lock)`.
+- Never write. All mutations MUST go through `zehut user …` /
+  `zehut configuration …` so the system-layer provisioning stays in
+  sync.
+```
+
+- [ ] **Step 3: Write `docs/testing.md`**
+
+Path: `/home/spark/git/zehut/docs/testing.md`
+
+```markdown
+# Testing zehut
+
+## Local unit tests
+
+```bash
+uv run pytest -n auto
+```
+
+Integration tests are marked `@pytest.mark.integration` and skip by
+default (they require real `useradd`/`userdel`).
+
+## Integration tests
+
+Two ways to run them:
+
+1. **As root on a disposable VM:**
+   ```bash
+   sudo -E uv run pytest -v -m integration
+   ```
+   Only do this on a throwaway machine — the tests create and destroy
+   OS users named `zht<hex>`.
+
+2. **Inside the CI Docker image:**
+   ```bash
+   docker build -t zehut-int -f .github/workflows/Dockerfile.integration .
+   docker run --rm -e ZEHUT_DOCKER=1 zehut-int \
+     uv run pytest tests/integration -v -m integration
+   ```
+
+## Test-only environment hooks
+
+Unit tests rely on these overrides; they are not user-facing features.
+
+- `ZEHUT_CONFIG_DIR` — overrides `/etc/zehut`. Tests point this at a
+  tmpdir so they never touch the real system.
+- `ZEHUT_STATE_DIR` — overrides `/var/lib/zehut`. Same rationale.
+- `ZEHUT_ASSUME_ROOT=1` — makes `zehut.privilege.is_root()` return
+  `True` regardless of actual euid. Used by `tests/test_self_verify.py`
+  to exercise the privilege-gated paths without running as root.
+- `ZEHUT_DOCKER=1` — signals the integration-test gate that we're
+  running inside the disposable CI container; otherwise integration
+  tests only run as real root.
+
+## Coverage
+
+`pyproject.toml` enforces a 70% floor via `[tool.coverage.report]
+fail_under = 70`. Local inspection:
+
+```bash
+uv run pytest --cov=zehut --cov-report=term-missing
+```
+```
+
+- [ ] **Step 4: Update `CLAUDE.md`**
+
+Path: `/home/spark/git/zehut/CLAUDE.md` — add a new section after the existing content, before the final line. The existing file currently ends with the "Workflow" section. Append:
+
+```markdown
+
+## Implementation status (post-v1)
+
+Implemented surface lives in `zehut/`:
+
+- CLI entry: `zehut/cli/__init__.py` (argparse, dispatch, `--json`, error routing).
+- Commands: `zehut/cli/_commands/{init,configuration,user,doctor,learn,overview,explain}.py`.
+- Core modules: `zehut/{fs,config,privilege,users}.py`.
+- Backends: `zehut/backend/{base,logical,system}.py`.
+
+State on disk:
+
+- `/etc/zehut/config.toml` (root-owned, 0o644).
+- `/var/lib/zehut/users.json` (root-owned, 0o644) — stable API consumed
+  by a separate (forthcoming) secrets CLI.
+
+Test-only env hooks (see `docs/testing.md`): `ZEHUT_CONFIG_DIR`,
+`ZEHUT_STATE_DIR`, `ZEHUT_ASSUME_ROOT`, `ZEHUT_DOCKER`.
+
+## Version bumps
+
+Every PR MUST bump the version. Run:
+
+```bash
+python3 .claude/skills/version-bump/scripts/bump.py {patch|minor|major}
+```
+
+Patch for docs/config/CI; minor for new commands or verbs; major for
+breaking changes (schema_version bump, removed verbs, exit-code
+reshuffle). The `version-check` job in `tests.yml` enforces this on PR.
+
+## Reference
+
+- Design spec: `docs/superpowers/specs/2026-04-24-zehut-cli-design.md`.
+- Implementation plan: `docs/superpowers/plans/2026-04-24-zehut-cli-v1.md`.
+- Threat model: `docs/threat-model.md`.
+- Identity model: `docs/identity-model.md`.
+- Testing notes: `docs/testing.md`.
+- Patterned on: `../afi-cli` (same CI, error-routing, and versioning
+  conventions).
+```
+
+- [ ] **Step 5: Rewrite `README.md`**
+
+Path: `/home/spark/git/zehut/README.md`
+
+```markdown
+# zehut
+
+Agents-first identity layer for Linux hosts.
+
+`zehut` provisions and tracks machine-local identities — either **system-backed**
+(real OS users via `useradd`) or **logical** (metadata only) — and gives each
+one a deterministic email address from a configured domain. A separate CLI
+consumes zehut's `users.json` registry to provide secrets management on top of
+this identity foundation.
+
+## Install
+
+```bash
+uv tool install zehut
+```
+
+## Quick start
+
+```bash
+# One-time bootstrap (needs sudo).
+sudo $(which zehut) init --domain agents.example.com --default-backend system
+
+# Create a system-backed user.
+sudo $(which zehut) user create alice --nick Ali --about "QA agent"
+
+# Create a logical (metadata-only) user.
+zehut user create bot --logical
+
+# List, show, switch.
+zehut user list
+zehut user show alice
+zehut user switch alice     # system: exec sudo -u alice -i
+eval "$(zehut user switch bot)"  # logical: sets ZEHUT_IDENTITY
+
+# Health check.
+zehut doctor
+```
+
+## Documentation
+
+- [Identity model](docs/identity-model.md)
+- [Threat model](docs/threat-model.md)
+- [Testing](docs/testing.md)
+- [Design spec](docs/superpowers/specs/2026-04-24-zehut-cli-design.md)
+
+## License
+
+MIT. See [LICENSE](LICENSE).
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add docs/threat-model.md docs/identity-model.md docs/testing.md \
+        CLAUDE.md README.md
+git commit -m "docs: threat-model, identity-model, testing; update CLAUDE.md and README"
+```
+
+---
+
+## Task 20: Pre-commit, markdownlint, and first publish dry-run
+
+**Goal:** Last mile: pre-commit hooks, markdown lint config, a script that mirrors afi-cli's `scripts/lint-md.sh`, and a local `uv build` dry-run to confirm the package builds a wheel before CI gets it.
+
+**Files:**
+- Create: `/home/spark/git/zehut/.pre-commit-config.yaml`
+- Create: `/home/spark/git/zehut/.markdownlint-cli2.yaml`
+- Create: `/home/spark/git/zehut/scripts/lint-md.sh`
+- Create: `/home/spark/git/zehut/CHANGELOG.md`
+
+- [ ] **Step 1: Write `.pre-commit-config.yaml`**
+
+Path: `/home/spark/git/zehut/.pre-commit-config.yaml`
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3.12
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bandit, flake8-bugbear]
+        args: ["--config=.flake8"]
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.13.0
+    hooks:
+      - id: markdownlint-cli2
+```
+
+- [ ] **Step 2: Write `.markdownlint-cli2.yaml`**
+
+Path: `/home/spark/git/zehut/.markdownlint-cli2.yaml`
+
+```yaml
+config:
+  default: true
+  MD013: false  # line-length
+  MD060: false  # no-hr-after-heading (lint-cli2 plugin unused here)
+  MD033:        # allow inline HTML (for the occasional <br>)
+    allowed_elements: [br, details, summary]
+
+globs:
+  - "**/*.md"
+ignores:
+  - "**/node_modules/**"
+  - "dist/**"
+  - "build/**"
+```
+
+- [ ] **Step 3: Write `scripts/lint-md.sh`**
+
+Path: `/home/spark/git/zehut/scripts/lint-md.sh`
+
+```bash
+#!/usr/bin/env bash
+# Lint (and auto-fix) markdown files tracked in git.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ $# -gt 0 ]]; then
+    files=("$@")
+else
+    mapfile -t files < <(git ls-files '*.md')
+fi
+
+if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
+    echo "markdownlint-cli2 not on PATH; install with: npm i -g markdownlint-cli2" >&2
+    exit 127
+fi
+
+markdownlint-cli2 --fix "${files[@]}"
+```
+
+Make it executable:
+
+```bash
+chmod +x /home/spark/git/zehut/scripts/lint-md.sh
+```
+
+- [ ] **Step 4: Write initial `CHANGELOG.md`**
+
+Path: `/home/spark/git/zehut/CHANGELOG.md`
+
+```markdown
+# Changelog
+
+All notable changes to `zehut` will be documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] — 2026-04-24
+
+### Added
+
+- Initial v1 release: `zehut init`, `zehut user create/list/show/set/delete/switch/whoami/current`,
+  `zehut configuration show/set/set-domain`, `zehut doctor`, `zehut learn`,
+  `zehut overview`, `zehut explain`.
+- System-backed and logical identity backings.
+- Deterministic email generation from a configurable pattern +
+  collision suffixing.
+- Ambient identity resolution (OS user → registry match →
+  `$ZEHUT_IDENTITY` fallback).
+- Root-owned machine state under `/etc/zehut/` and `/var/lib/zehut/`,
+  with `fcntl` locking and atomic rename.
+- Zero runtime dependencies (stdlib only).
+- CI: lint, unit tests, Docker-gated integration tests, Trusted
+  Publishing to TestPyPI (on PR) and PyPI (on push to `main`).
+
+[Unreleased]: https://github.com/OriNachum/zehut/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/OriNachum/zehut/releases/tag/v0.1.0
+```
+
+- [ ] **Step 5: Build dry-run**
+
+```bash
+cd /home/spark/git/zehut
+uv build
+ls dist/
+```
+
+Expected: `dist/zehut-0.1.0-py3-none-any.whl` and `dist/zehut-0.1.0.tar.gz`. If you see them, the wheel is publishable.
+
+- [ ] **Step 6: Install-from-wheel smoke test**
+
+```bash
+cd /home/spark/git/zehut
+# Uninstall if a prior tool install exists.
+uv tool uninstall zehut 2>/dev/null || true
+uv tool install ./dist/zehut-0.1.0-py3-none-any.whl
+zehut --version
+```
+
+Expected: prints `zehut 0.1.0`.
+
+- [ ] **Step 7: Run the full test suite one last time**
+
+```bash
+cd /home/spark/git/zehut
+uv run pytest -n auto
+```
+
+Expected: all unit tests pass; integration tests skip (unless ZEHUT_DOCKER=1 or root).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/spark/git/zehut
+git add .pre-commit-config.yaml .markdownlint-cli2.yaml scripts/lint-md.sh CHANGELOG.md
+git commit -m "chore: pre-commit hooks, markdownlint config, CHANGELOG"
+```
+
+- [ ] **Step 9: Open the PR**
+
+```bash
+cd /home/spark/git/zehut
+git push -u origin feat/v1-scaffold
+gh pr create --base main --title "feat: v1 scaffold — identity layer (closes greenfield)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- First working version of `zehut`: the identity layer of the broader agents-first secrets system.
+- Noun-verb CLI (`zehut user`, `zehut configuration`) + agent-first globals (`init`, `doctor`, `learn`, `overview`, `explain`).
+- System-backed identities via `useradd`/`userdel`; logical identities for metadata-only accounts; ambient OS-user resolution.
+- State on disk: `/etc/zehut/config.toml` + `/var/lib/zehut/users.json` (stable contract for a separate secrets CLI).
+- Zero runtime deps. CI: lint, unit tests, Dockerised integration tests, Trusted Publishing to TestPyPI on PR / PyPI on merge.
+
+See the [design spec](docs/superpowers/specs/2026-04-24-zehut-cli-design.md) and [implementation plan](docs/superpowers/plans/2026-04-24-zehut-cli-v1.md) for context.
+
+## Test plan
+
+- [ ] CI green (lint, unit, integration-in-docker, version-check)
+- [ ] TestPyPI wheel installs cleanly from `uv tool install --index-url https://test.pypi.org/simple zehut`
+- [ ] Manual smoke on a disposable VM:
+  - [ ] `sudo zehut init --domain agents.example.com --default-backend system`
+  - [ ] `sudo zehut user create alice --nick Ali`
+  - [ ] `zehut user switch alice` → shell becomes alice → `zehut user whoami` → "alice"
+  - [ ] `sudo zehut user delete alice`
+  - [ ] `zehut doctor` — all PASS
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+After finishing Task 20, before requesting review:
+
+1. **Spec coverage.** Walk through `docs/superpowers/specs/2026-04-24-zehut-cli-design.md`
+   section by section. For each requirement, point at the task that implements it.
+   - §3 CLI surface → Tasks 10-16
+   - §4 Architecture / module layout → Tasks 2-9
+   - §5 State schema → Tasks 2, 4, 9
+   - §6 Error model + exit codes + doctor checks → Tasks 5, 15
+   - §7 Packaging / versioning / CI → Tasks 1, 17, 20
+   - §8 Testing strategy → Tasks 8, 17, 18
+   - §9 Threat model → Task 19
+
+2. **Placeholder scan.** Grep the plan for `TBD`, `TODO`, `fill in`, `implement later`:
+   ```bash
+   grep -nE 'TBD|TODO|fill in|implement later' docs/superpowers/plans/2026-04-24-zehut-cli-v1.md
+   ```
+   Expected: no hits in task steps (the word "TODO" may appear in tests or example strings — visually verify those are intentional).
+
+3. **Type / name consistency.** Scan for references to functions/classes across tasks:
+   - `ZehutError` — defined Task 5, used in every command task. Signature
+     `ZehutError(code, message, remediation)` consistent everywhere.
+   - `fs.atomic_write_text(target, data, *, mode)` — defined Task 2, used in
+     Tasks 4 and 9.
+   - `users.add(name, nick, about, backend_name, backend)` — defined Task 9,
+     called in Task 12.
+   - `users.ambient_name()` — defined Task 9, called in Tasks 13, 14, 15.
+   - `privilege.require_root(*, action, argv)` — defined Task 3, called in
+     Tasks 10, 11, 12, 13.
+
+4. **Commit sequence.** Every task ends in a single commit. No task depends
+   on uncommitted work from a later task.
+
+---
+
+## Execution handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-24-zehut-cli-v1.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — I execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-24-zehut-cli-design.md
+++ b/docs/superpowers/specs/2026-04-24-zehut-cli-design.md
@@ -1,0 +1,425 @@
+# zehut CLI — v1 design
+
+**Date:** 2026-04-24
+**Status:** Draft (pending user review)
+**Applies to:** `zehut` package on PyPI / TestPyPI
+
+## 1. Overview
+
+`zehut` is the **identity layer** of a broader agents-first secrets-management
+system. Secrets themselves are delivered by a separate CLI / package, which
+consumes the identity registry this package exposes. This scope split is
+deliberate: identity is a stable, small, security-critical foundation that
+benefits from being shipped, versioned, and reviewed independently of the
+secret-handling surface.
+
+A zehut identity (a "user" in v1) is:
+
+- a stable ULID `id`,
+- a primary `name`,
+- optional profile metadata (`nick`, `about`),
+- an auto-generated email (deterministic from `name` and/or `nick` + configured domain; default pattern is `{name}`, configurable),
+- a backing: **system** (real local OS user created via `useradd`) or
+  **logical** (metadata-only, no OS account).
+
+Mental model in one sentence: **on a zehut machine, the OS user *is* the
+identity; logical users are a superset for cases where no OS account is
+wanted.**
+
+The CLI mirrors the conventions of
+[`afi-cli`](https://github.com/agentculture/afi-cli) (noun-verb argparse,
+structured errors with exit codes and remediation, mandatory per-PR version
+bump, Trusted-Publisher CI, agent-first globals).
+
+## 2. Scope
+
+### In scope for v1
+
+- Identity lifecycle: create, list, show, switch, whoami, set, delete.
+- System-backed isolation via `useradd` / `userdel`.
+- Logical identities with env-var switching.
+- Deterministic email generation from a configured domain.
+- Machine-wide configuration (`/etc/zehut/config.toml`).
+- Machine-wide user registry (`/var/lib/zehut/users.json`).
+- Agent-first globals: `init`, `doctor`, `learn`, `overview`, `explain`.
+- Ambient identity resolution (the OS user *is* the current zehut user).
+
+### Explicitly out of scope for v1
+
+- **Secrets.** Delivered by a separate CLI/package; not in `zehut`.
+- **Email provider integration.** Emails are metadata; MX/deliverability is
+  the operator's problem.
+- **MCP / HTTP surfaces.** `afi-cli` will scaffold those later; v1 is
+  CLI-only.
+- **Adopting foreign OS users.** `create alice --system` refuses when
+  `/etc/passwd` already has `alice` but the registry does not.
+- **`user rename`.** The ULID `id` exists so rename is cheap later, but the
+  verb isn't in v1.
+- **Schema migrations.** `schema_version` is recorded but there is no
+  `zehut migrate`; first breaking change will ship it.
+- **Remote/cloud backends** (KMS, HSM, vault) — deferred; named as future
+  risk surfaces in `docs/threat-model.md`.
+- **Audit log.** No mutation journal in v1.
+- **Caller auth beyond sudo.** v1 trusts `geteuid()` + sudoers policy.
+- **Multi-machine.** Single host; federation is v3+.
+
+### v2 candidates (this package, not secrets)
+
+1. `zehut migrate` + `schema_version` stepper.
+2. `zehut user rename` (leveraging stable ULID).
+3. `zehut doctor --adopt` for registering pre-existing OS users.
+4. Audit log (append-only JSONL under `/var/lib/zehut/audit/`).
+5. Email provider plug layer + `zehut email verify <name>` round-trip probe.
+
+Secrets do not appear here because they belong to a different package.
+
+## 3. CLI surface
+
+Noun-verb shape, following `afi` conventions. Top-level globals live
+alongside two nouns: `user` and `configuration`.
+
+### 3.1 Globals
+
+| Command | Purpose | Needs root? |
+|---|---|---|
+| `zehut init` | Bootstrap `/etc/zehut/config.toml` + `/var/lib/zehut/users.json`. Prompts for `domain` and `default_backend`. Idempotent. | yes |
+| `zehut doctor` | Run health checks (see §6). | no |
+| `zehut learn` | Emit an agent-authored skill describing how to drive zehut (afi-style). | no |
+| `zehut overview [--json]` | Full snapshot: config + users + emails + backing types. | no |
+| `zehut explain <topic>` | Human-readable explanation of a command or concept (e.g. `zehut explain user switch`). | no |
+
+### 3.2 `zehut configuration`
+
+| Verb | Purpose | Needs root? |
+|---|---|---|
+| `configuration show [--json]` | Render current `/etc/zehut/config.toml`. | no |
+| `configuration set <key> <value>` | Mutate a single key (`domain`, `default_backend`, `email.pattern`, `email.collision`). | yes |
+| `configuration set-domain <domain>` | Convenience alias for the most common op. | yes |
+
+### 3.3 `zehut user`
+
+| Verb | Purpose | Needs root? |
+|---|---|---|
+| `user create <name> [--system\|--logical] [--nick=…] [--about=…]` | Provision user. `--system`: `useradd` + homedir + registry write. `--logical`: registry write only. Default is `configuration.defaults.backend`. | yes iff `--system` |
+| `user list [--json]` | Enumerate users: `name`, `backend`, `email`. | no |
+| `user show [<name>] [--json]` | Full record. Omit `<name>` → ambient identity. | no |
+| `user switch <name>` | System-backed: exec `sudo -u <sysuser> -i` (replaces the shell). Logical: print `export ZEHUT_IDENTITY=<name>` for `eval $(zehut user switch alice)`. | no (system call prompts via sudo) |
+| `user whoami [--json]` | Print ambient identity (see §3.4). Non-zero exit if none. Aliased as `user current`. | no |
+| `user set [<name>] <key>=<value>` | Mutate `nick`, `about`. Backing and email immutable post-create in v1. Omit `<name>` → ambient identity. | yes |
+| `user delete <name> [--keep-home]` | Registry removal + `userdel` for system-backed. `--keep-home` preserves the home directory. | yes iff system-backed |
+
+No `email` noun in v1: emails are auto-generated at `create` from the
+configured domain + pattern and stored immutably on the user record.
+
+### 3.4 Ambient identity resolution
+
+Any verb that references a "current" user resolves in this order:
+
+1. **Ambient OS user.** Look up `pwd.getpwuid(os.geteuid()).pw_name` in the
+   registry. If the running process's OS user matches a zehut-managed
+   system-backed user, that is the identity. Zero configuration for agents
+   launched under a zehut-provisioned user (Claude Agent SDK, cron, systemd,
+   `sudo -u usera …` — all automatic).
+2. **`$ZEHUT_IDENTITY` env var.** For logical users, or to explicitly
+   override inside an OS user's shell.
+3. **Nothing.** Commands that require a current identity exit with
+   `EXIT_USER_ERROR` and remediation `run 'zehut user switch <name>' or
+   'zehut user create <name>' first`.
+
+## 4. Architecture
+
+### 4.1 Package layout
+
+```text
+zehut/
+├── .claude/skills/version-bump/     # vendored from afi-cli
+├── .github/workflows/
+│   ├── tests.yml
+│   ├── publish.yml
+│   └── security-checks.yml
+├── .markdownlint-cli2.yaml
+├── CHANGELOG.md
+├── CLAUDE.md
+├── LICENSE
+├── README.md
+├── docs/
+│   ├── threat-model.md
+│   ├── identity-model.md
+│   ├── testing.md
+│   └── superpowers/specs/2026-04-24-zehut-cli-design.md
+├── pyproject.toml
+├── scripts/lint-md.sh
+├── tests/
+│   ├── unit/
+│   ├── integration/                 # gated: real useradd; runs in Docker in CI
+│   ├── test_cli.py
+│   └── test_self_verify.py
+├── uv.lock
+└── zehut/
+    ├── __init__.py                  # __version__ via importlib.metadata
+    ├── __main__.py
+    ├── backend/
+    │   ├── base.py                  # Backend ABC
+    │   ├── logical.py
+    │   └── system.py                # useradd/userdel wrapper
+    ├── cli/
+    │   ├── __init__.py              # main, _build_parser, _dispatch
+    │   ├── _commands/
+    │   │   ├── configuration.py
+    │   │   ├── doctor.py
+    │   │   ├── explain.py
+    │   │   ├── init.py
+    │   │   ├── learn.py
+    │   │   ├── overview.py
+    │   │   └── user.py
+    │   ├── _errors.py               # ZehutError + EXIT_* constants
+    │   └── _output.py               # emit_result / emit_diagnostic / emit_error
+    ├── config.py
+    ├── fs.py                        # paths, fcntl locking, atomic write
+    ├── privilege.py                 # geteuid check + sudo advice
+    └── users.py                     # registry CRUD + email generation
+```
+
+### 4.2 Module responsibilities
+
+| Module | Responsibility | Depends on |
+|---|---|---|
+| `zehut.cli` | argparse plumbing, dispatch, error routing. Pure UI — no state mutation. | `_errors`, `_output`, noun handlers |
+| `zehut.config` | Load/save/validate `config.toml`, apply defaults, enforce schema_version. | `fs` |
+| `zehut.users` | Registry CRUD, email generation, ULID issuance, collision resolution. | `fs`, `config`, `backend` |
+| `zehut.backend` | Backend ABC + `system`/`logical` strategies. Only place that shells out to `useradd`/`userdel`. | `privilege` |
+| `zehut.fs` | Path constants (respecting `ZEHUT_CONFIG_DIR`/`ZEHUT_STATE_DIR` env overrides), `fcntl` locking, atomic write-temp-then-rename. | stdlib only |
+| `zehut.privilege` | `geteuid()` check, sudo-advice message construction, detects `uv tool` PATH pitfall for `sudo zehut`. | stdlib only |
+
+All handlers raise `ZehutError`; `_dispatch` catches and exits with the code.
+No Python tracebacks leak to users.
+
+### 4.3 The registry as a contract
+
+`/var/lib/zehut/users.json` is the **stable API surface** the separate
+secrets CLI consumes. Breaking changes to its schema bump `schema_version`
+and require a coordinated release. Internal modules always read/write the
+registry through `zehut.users`, never directly — so the on-disk format can
+change without touching the rest of the package.
+
+## 5. State schema
+
+### 5.1 Files
+
+```text
+/etc/zehut/config.toml         0644  root:root
+/var/lib/zehut/users.json      0644  root:root
+/var/lib/zehut/.lock           0644  root:root  (fcntl advisory lock)
+```
+
+Paths are overridable for tests via `ZEHUT_CONFIG_DIR` and
+`ZEHUT_STATE_DIR` (documented in `docs/testing.md`; not advertised to end
+users).
+
+### 5.2 `config.toml`
+
+```toml
+schema_version = 1
+
+[defaults]
+backend = "system"          # "system" | "logical" — chosen at init
+
+[email]
+domain = "agents.example.com"
+pattern = "{name}"          # tokens: {name}, {nick}, {id-short}. Fallback: "{nick|name}"
+collision = "suffix"        # "-2", "-3", … up to 99 then EXIT_CONFLICT
+```
+
+### 5.3 `users.json`
+
+```json
+{
+  "schema_version": 1,
+  "users": [
+    {
+      "id": "01HYA9...",
+      "name": "alice",
+      "nick": "Ali",
+      "about": "QA agent",
+      "email": "ali@agents.example.com",
+      "backend": "system",
+      "system_user": "alice",
+      "system_uid": 1001,
+      "created_at": "2026-04-24T12:00:00Z",
+      "updated_at": "2026-04-24T12:00:00Z"
+    }
+  ]
+}
+```
+
+- `id` is a ULID — immutable, stable across future renames.
+- `name` is the primary handle; for system-backed it MUST equal
+  `system_user`.
+- `system_uid` is recorded at create time for drift detection in `doctor`.
+
+### 5.4 I/O discipline
+
+- Writers take `fcntl.LOCK_EX` on `.lock`; readers take `LOCK_SH`.
+- Every write: `write_text(tmp)` → `os.fsync` → `os.replace(tmp, target)`.
+- Reads validate `schema_version == 1`; mismatches raise `EXIT_STATE` with
+  `run 'zehut migrate' when available (not yet in v1)`.
+
+### 5.5 Transactional ordering
+
+| Op | Order | Rationale |
+|---|---|---|
+| `create --system` | `useradd` → registry write | If registry write crashes, the orphan OS user is detectable by `doctor`. No registry entry ever points at a missing uid. |
+| `delete --system` | registry remove → `userdel` | If `userdel` crashes, registry is clean; orphan OS user is detectable by `doctor`. |
+| `set` | registry only, atomic | No OS state change in v1. |
+
+## 6. Error model
+
+Handlers raise `ZehutError(code, message, remediation)`.
+`zehut.cli._dispatch` catches, routes through `_output.emit_error` (text or
+JSON depending on `--json`), and returns the exit code. Unknown exceptions
+are wrapped into an `EXIT_INTERNAL` `ZehutError`.
+
+### 6.1 Exit codes
+
+| Code | Name | Meaning |
+|---|---|---|
+| 0 | `EXIT_SUCCESS` | — |
+| 64 | `EXIT_USER_ERROR` | Bad args, unknown name, verb pre-conditions unmet. |
+| 65 | `EXIT_STATE` | Uninitialized or corrupt state (missing files, schema mismatch). |
+| 66 | `EXIT_PRIVILEGE` | Operation requires root and current euid is not 0. |
+| 67 | `EXIT_BACKEND` | OS-level op failed (`useradd`/`userdel` non-zero). |
+| 68 | `EXIT_CONFLICT` | Name / email / uid collision. |
+| 70 | `EXIT_INTERNAL` | Wrapped unexpected exception. Ships a bug-report hint. |
+
+### 6.2 Notable error surfaces
+
+- **Needs sudo.** `user create --system` without root: `EXIT_PRIVILEGE`
+  with `re-run with: sudo $(which zehut) user create alice --system`.
+  `privilege.py` adds the `$(which zehut)` hint because `uv tool install`
+  places the binary in `~/.local/bin`, which is not on root's `secure_path`.
+- **Not initialized.** `EXIT_STATE`, remediation `run: sudo zehut init`.
+- **Foreign OS user.** `create alice --system` when `alice` exists in
+  `/etc/passwd` but not in the registry: `EXIT_CONFLICT`, remediation
+  `pick a different name; v2 will add 'doctor --adopt'`.
+- **Email collision beyond suffix limit.** `EXIT_CONFLICT`, remediation
+  `pass --nick=<distinct>`.
+- **Registry ↔ OS drift.** `doctor` reports (does not fix) registry
+  entries whose `system_uid` no longer matches `/etc/passwd`, and OS users
+  whose name matches a *logical* zehut user.
+
+### 6.3 `doctor` checks
+
+Each returns `PASS` / `FAIL` / `WARN` with remediation.
+
+1. `/etc/zehut/config.toml` exists, parses, has required keys, `schema_version == 1`.
+2. `/var/lib/zehut/users.json` exists, parses, `schema_version == 1`.
+3. File modes / ownership match expectations (0644 root:root).
+4. `useradd`, `userdel`, `id` are on `PATH` (only required if any
+   system-backed users exist).
+5. For each system-backed entry: `pwd.getpwnam(system_user)` resolves and
+   the uid matches `system_uid`.
+6. No OS-user name collides with any *logical* zehut user name.
+7. Ambient resolution: if the current OS user is zehut-managed, registry
+   agrees with `os.geteuid()`.
+8. `email.domain` is well-formed (format check only; no DNS/MX in v1).
+
+## 7. Packaging, versioning, CI
+
+### 7.1 Packaging
+
+- `pyproject.toml`: hatchling, `requires-python = ">=3.12"`.
+- **Zero runtime dependencies** — stdlib only (argparse, tomllib, json,
+  fcntl, pwd, subprocess, pathlib, uuid/ulid via a small vendored helper or
+  stdlib `uuid.uuid7()` on 3.14+ / minimal ULID impl on 3.12–3.13).
+- `project.scripts`: `zehut = "zehut.cli:main"`.
+- Install: `uv tool install zehut`. Privileged verbs: `sudo $(which zehut) …`.
+- Published on PyPI (existing package reservation) and TestPyPI.
+- First published version: `0.1.0` (pre-alpha classifier).
+
+### 7.2 Dev dependency group
+
+Identical to `afi-cli`: pytest, pytest-xdist, pytest-cov, bandit, pylint,
+flake8, flake8-bandit, flake8-bugbear, coverage, pre-commit, isort, black.
+
+### 7.3 Versioning (mirror of afi strategy)
+
+- **Every PR bumps.** Enforced by the `version-check` job in `tests.yml`,
+  which compares `HEAD`'s `project.version` against `main`'s.
+- `.claude/skills/version-bump/` is vendored from afi-cli. Usage:
+  `python3 .claude/skills/version-bump/scripts/bump.py {patch|minor|major}`
+  with a JSON changelog object on stdin.
+- Defaults: **patch** for docs/config/CI, **minor** for new commands or
+  verbs, **major** for breaking changes (schema_version bump, removed
+  verbs, exit-code reshuffle).
+- `CHANGELOG.md` entries 1:1 with merged PRs.
+- `zehut/__init__.py`: `__version__ = importlib.metadata.version("zehut")` —
+  single source of truth in `pyproject.toml`.
+
+### 7.4 CI workflows
+
+| Workflow | Trigger | Jobs |
+|---|---|---|
+| `tests.yml` | PR, push to main | lint (flake8/pylint/bandit/black/isort), pytest matrix, `version-check`, markdown lint |
+| `publish.yml` | PR → TestPyPI; push to `main` → PyPI | Trusted Publishing (OIDC), `uv build`, upload |
+| `security-checks.yml` | weekly + manual | bandit, pip-audit, trivy fs scan |
+
+### 7.5 Markdown linting
+
+`.markdownlint-cli2.yaml` at repo root (MD013/MD060 disabled — parity
+with afi-cli). `scripts/lint-md.sh` wraps `markdownlint-cli2 --fix`.
+Pre-commit runs it in check-only mode.
+
+## 8. Testing strategy
+
+- **Unit tests.** No network, no real sudo, no real `useradd`. Cover every
+  module. Use `ZEHUT_CONFIG_DIR` / `ZEHUT_STATE_DIR` tmp overrides.
+- **Integration tests** under `tests/integration/`. Shell out to real
+  `useradd`/`userdel`. Gated:
+  `@pytest.mark.skipif(os.geteuid() != 0 and not os.getenv("ZEHUT_DOCKER"))`.
+  CI runs them inside a disposable Docker container; local `main` stays
+  green without polluting the runner.
+- **`test_self_verify.py`.** Dogfood: tmpdir-rooted lifecycle
+  (`init → create logical → list → whoami → delete`), then assert
+  `zehut doctor --json` returns all-PASS. Parallels afi-cli's self-verify.
+- **Coverage floor:** 70% (`pyproject.toml` `[tool.coverage.report]
+  fail_under = 70`).
+
+## 9. Threat model (stub — full text in `docs/threat-model.md`)
+
+- **Trust boundary.** The host OS + sudoers policy.
+- **Adversary model (v1).** Single-admin trusted host. Non-root local
+  users must not be able to escalate via zehut, tamper with the registry,
+  or impersonate another zehut user.
+- **Risk surfaces to enumerate:**
+  1. Privileged subprocess invocation of `useradd` / `userdel` (argument
+     sanitization, `PATH` pinning to `/usr/sbin:/usr/bin`).
+  2. TOCTOU between `geteuid()` check and subprocess invocation.
+  3. Registry file tampering (writable only by root; readers take shared
+     lock; mode/owner validated by `doctor`).
+  4. Email domain takeover (out of zehut's control; called out).
+  5. Unprotected state during `init` (create files with restrictive perms
+     first, then populate).
+
+## 10. Open questions left for implementation
+
+These are small enough that the implementation plan can resolve them; they
+don't require further spec-level brainstorming:
+
+- Exact ULID implementation (stdlib `uuid.uuid7` vs a ~30-line vendored
+  ULID generator). Decide when writing `zehut.users`.
+- Precise `useradd` flag set (default shell, group handling, skel).
+  Document chosen flags in `zehut.backend.system` with citations to
+  `useradd(8)`.
+- Whether `doctor` should have a `--fix` flag in v1 for safe repairs
+  (permissions only) or leave all repairs to v2. Recommend: read-only in
+  v1, clearer boundary.
+
+## 11. Acceptance for v1
+
+- All commands in §3 implemented and covered by unit tests.
+- `zehut doctor --json` returns all-PASS on a clean `init` + create/delete
+  cycle (logical *and* system, the latter in Docker CI).
+- `tests.yml` passes with `version-check`, lint, and pytest.
+- `publish.yml` successfully uploads `0.1.0` to TestPyPI on PR.
+- `docs/threat-model.md` and `docs/identity-model.md` exist and are
+  linked from `README.md`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,54 @@
+# Testing zehut
+
+## Local unit tests
+
+```bash
+uv run pytest -n auto
+```
+
+Integration tests are marked `@pytest.mark.integration` and skip by
+default (they require real `useradd`/`userdel`).
+
+## Integration tests
+
+Two ways to run them:
+
+1. **As root on a disposable VM:**
+
+   ```bash
+   sudo -E uv run pytest -v -m integration
+   ```
+
+   Only do this on a throwaway machine — the tests create and destroy
+   OS users named `zht<hex>`.
+
+2. **Inside the CI Docker image:**
+
+   ```bash
+   docker build -t zehut-int -f .github/workflows/Dockerfile.integration .
+   docker run --rm -e ZEHUT_DOCKER=1 zehut-int \
+     uv run pytest tests/integration -v -m integration
+   ```
+
+## Test-only environment hooks
+
+Unit tests rely on these overrides; they are not user-facing features.
+
+- `ZEHUT_CONFIG_DIR` — overrides `/etc/zehut`. Tests point this at a
+  tmpdir so they never touch the real system.
+- `ZEHUT_STATE_DIR` — overrides `/var/lib/zehut`. Same rationale.
+- `ZEHUT_ASSUME_ROOT=1` — makes `zehut.privilege.is_root()` return
+  `True` regardless of actual euid. Used by `tests/test_self_verify.py`
+  to exercise the privilege-gated paths without running as root.
+- `ZEHUT_DOCKER=1` — signals the integration-test gate that we're
+  running inside the disposable CI container; otherwise integration
+  tests only run as real root.
+
+## Coverage
+
+`pyproject.toml` enforces a 70% floor via `[tool.coverage.report]
+fail_under = 70`. Local inspection:
+
+```bash
+uv run pytest --cov=zehut --cov-report=term-missing
+```

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,76 @@
+# zehut threat model (v1)
+
+## Trust boundary
+
+The host OS and its sudoers policy. zehut is a privileged CLI: any caller
+who can become root can do everything zehut can do anyway. zehut's job is
+to be a well-behaved privileged caller — not to enforce authorisation
+above the OS layer.
+
+## Adversary model (v1)
+
+Single-admin trusted host. Non-root local users MUST NOT be able to:
+
+1. Escalate privileges via a zehut invocation.
+2. Tamper with `/var/lib/zehut/users.json` or `/etc/zehut/config.toml`.
+3. Impersonate another zehut user through ambient resolution.
+
+Multi-tenant hosts, network services, and cloud identity backends are
+out of scope for v1.
+
+## Risk surfaces
+
+### 1. Privileged subprocess invocation (`useradd` / `userdel`)
+
+- `PATH` is pinned to `/usr/sbin:/usr/bin` on every `subprocess.run` call
+  in `zehut/backend/system.py`.
+- `LC_ALL=C` is set so error parsing is stable across locales.
+- Names are validated against `^[a-z_][a-z0-9_-]{0,31}$` before they
+  reach the subprocess — rejects shell metacharacters at the zehut
+  layer.
+- Flags are hard-coded; user input never lands in a flag position.
+
+### 2. TOCTOU between `geteuid()` and subprocess
+
+- `privilege.require_root()` is called as late as possible (inside the
+  handler, before any state mutation). A successful check is immediately
+  followed by the privileged subprocess; there is no user-controlled
+  I/O in between that could trigger a suid change.
+- Python processes cannot drop/gain privileges between calls without
+  `setuid`; zehut never calls `setuid`.
+
+### 3. Registry file tampering
+
+- `users.json` and `config.toml` live in root-owned directories with
+  mode 0o644. Non-root users can read (needed for `whoami` / `list`)
+  but cannot write.
+- `doctor` validates modes and ownership; any drift is reported as
+  `WARN`.
+- Writers hold `fcntl.LOCK_EX` on `.lock` and use
+  write-temp→fsync→rename. A concurrent reader holding `LOCK_SH`
+  observes the old file until rename completes.
+
+### 4. Email domain takeover
+
+- Out of zehut's control. The configured domain's DNS/MX posture is the
+  operator's responsibility. `doctor` only validates syntactic
+  well-formedness.
+- Documented here so operators understand the boundary.
+
+### 5. Unprotected state during `init`
+
+- `init` creates `config.toml` and `users.json` via
+  `fs.atomic_write_text(..., mode=0o644)`, which uses `mkstemp` with
+  default 0o600 perms before the explicit `chmod 0o644`. There is no
+  window in which either file is world-readable without being also
+  world-unwritable.
+
+## Known non-goals (v2+)
+
+- Caller authentication beyond sudo.
+- Audit log of mutations.
+- Remote/cloud backends.
+- Multi-machine federation.
+
+These are tracked in the design spec's "v2 candidates" and will each get
+a threat-model update when added.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,79 @@
+[project]
+name = "zehut"
+version = "0.1.0"
+description = "Agents-first identity layer — local system & logical user registry with email assignment."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.12"
+authors = [{name = "Ori Nachum"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: System :: Systems Administration :: Authentication/Directory",
+    "Intended Audience :: System Administrators",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/OriNachum/zehut"
+Issues = "https://github.com/OriNachum/zehut/issues"
+
+[project.scripts]
+zehut = "zehut.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["zehut"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "pytest-xdist>=3.0",
+    "pytest-cov>=4.1",
+    "bandit>=1.7.5",
+    "pylint>=2.17.0",
+    "flake8>=6.1",
+    "flake8-bandit>=4.1.1",
+    "flake8-bugbear>=23.7.10",
+    "coverage>=7.2.0",
+    "pre-commit>=3.5.0",
+    "isort>=5.12.0",
+    "black>=23.7.0",
+]
+
+[tool.coverage.run]
+source = ["zehut"]
+omit = ["zehut/__pycache__/*"]
+
+[tool.coverage.report]
+fail_under = 70
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.isort]
+profile = "black"
+line_length = 100
+known_first_party = ["zehut"]
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+markers = [
+    "integration: tests that shell out to real useradd/userdel (gated on root or ZEHUT_DOCKER=1)",
+]

--- a/scripts/lint-md.sh
+++ b/scripts/lint-md.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Lint (and auto-fix) markdown files tracked in git.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ $# -gt 0 ]]; then
+    files=("$@")
+else
+    mapfile -t files < <(git ls-files '*.md')
+fi
+
+if ! command -v markdownlint-cli2 >/dev/null 2>&1; then
+    echo "markdownlint-cli2 not on PATH; install with: npm i -g markdownlint-cli2" >&2
+    exit 127
+fi
+
+markdownlint-cli2 --fix "${files[@]}"

--- a/tests/integration/test_backend_system_integration.py
+++ b/tests/integration/test_backend_system_integration.py
@@ -1,0 +1,43 @@
+"""Integration tests for SystemBackend — requires real useradd/userdel.
+
+Gated: only runs as root OR when ``ZEHUT_DOCKER=1`` is set. CI runs these
+inside a disposable container. Local dev machines skip them by default.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import uuid
+
+import pytest
+
+from zehut.backend.system import SystemBackend
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        os.geteuid() != 0 and os.environ.get("ZEHUT_DOCKER") != "1",
+        reason="requires root or ZEHUT_DOCKER=1",
+    ),
+]
+
+
+def _unique_name() -> str:
+    # useradd caps names at 32; take an 8-char hex chunk.
+    return "zht" + uuid.uuid4().hex[:8]
+
+
+def test_provision_then_deprovision_roundtrip():
+    name = _unique_name()
+    be = SystemBackend()
+    try:
+        result = be.provision(name=name)
+        assert result.system_user == name
+        assert isinstance(result.system_uid, int)
+        assert be.exists(name) is True
+        assert pwd.getpwnam(name).pw_uid == result.system_uid
+    finally:
+        if be.exists(name):
+            be.deprovision(name=name, system_user=name, keep_home=False)
+    assert be.exists(name) is False

--- a/tests/test_self_verify.py
+++ b/tests/test_self_verify.py
@@ -1,0 +1,62 @@
+"""End-to-end self-verify: a full lifecycle against a tmpdir-rooted zehut.
+
+Runs the CLI as a subprocess so argv parsing, env resolution, and exit
+codes are exercised the way a user or agent would invoke them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def zehut_env(tmp_path):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    config_dir.mkdir()
+    state_dir.mkdir()
+    env = os.environ.copy()
+    env["ZEHUT_CONFIG_DIR"] = str(config_dir)
+    env["ZEHUT_STATE_DIR"] = str(state_dir)
+    env["ZEHUT_ASSUME_ROOT"] = "1"
+    env.pop("ZEHUT_IDENTITY", None)
+    return env
+
+
+def _run(env: dict, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "zehut", *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_full_logical_lifecycle(zehut_env):
+    env = zehut_env
+
+    rc = _run(env, "init", "--domain", "agents.example.com", "--default-backend", "logical")
+    assert rc.returncode == 0, rc.stderr
+
+    rc = _run(env, "user", "create", "alice", "--nick", "Ali")
+    assert rc.returncode == 0, rc.stderr
+
+    rc = _run(env, "--json", "user", "list")
+    assert rc.returncode == 0
+    payload = json.loads(rc.stdout.splitlines()[-1])
+    assert payload[0]["name"] == "alice"
+
+    rc = _run(env, "--json", "doctor")
+    assert rc.returncode == 0
+    doctor_payload = json.loads(rc.stdout.splitlines()[-1])
+    statuses = {c["status"] for c in doctor_payload["checks"]}
+    assert "FAIL" not in statuses, doctor_payload
+
+    rc = _run(env, "user", "delete", "alice")
+    assert rc.returncode == 0, rc.stderr

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,24 @@
+"""Smoke tests — prove the package is importable and --version works."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import zehut
+
+
+def test_version_attribute_exists() -> None:
+    assert isinstance(zehut.__version__, str)
+    assert zehut.__version__  # non-empty
+
+
+def test_cli_version_flag() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "zehut", "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "zehut" in result.stdout

--- a/tests/unit/test_backend_logical.py
+++ b/tests/unit/test_backend_logical.py
@@ -1,0 +1,30 @@
+"""Unit tests for zehut.backend.logical."""
+
+from __future__ import annotations
+
+from zehut.backend import logical
+from zehut.backend.base import Backend, ProvisionResult
+
+
+def test_logical_backend_is_a_backend():
+    assert isinstance(logical.LogicalBackend(), Backend)
+
+
+def test_provision_returns_result_with_no_system_uid():
+    be = logical.LogicalBackend()
+    result = be.provision(name="alice")
+    assert isinstance(result, ProvisionResult)
+    assert result.system_user is None
+    assert result.system_uid is None
+
+
+def test_deprovision_is_a_noop():
+    be = logical.LogicalBackend()
+    # Should not raise regardless of whether 'alice' exists anywhere.
+    be.deprovision(name="alice", system_user=None, keep_home=False)
+
+
+def test_exists_returns_false_for_any_name():
+    be = logical.LogicalBackend()
+    assert be.exists("alice") is False
+    assert be.exists("root") is False

--- a/tests/unit/test_backend_system.py
+++ b/tests/unit/test_backend_system.py
@@ -1,0 +1,110 @@
+"""Unit tests for zehut.backend.system — all subprocess calls mocked."""
+
+from __future__ import annotations
+
+import subprocess
+import types
+
+import pytest
+
+from zehut.backend import system
+from zehut.backend.base import ProvisionResult
+from zehut.cli._errors import EXIT_BACKEND, EXIT_USER_ERROR, ZehutError
+
+
+@pytest.fixture
+def fake_pwd(monkeypatch):
+    """Install a fake ``pwd.getpwnam`` that returns a predictable record."""
+    entries: dict[str, int] = {}
+
+    def _getpwnam(name: str):
+        if name not in entries:
+            raise KeyError(name)
+        return types.SimpleNamespace(pw_name=name, pw_uid=entries[name])
+
+    monkeypatch.setattr(system.pwd, "getpwnam", _getpwnam)
+    return entries
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Record subprocess.run calls and simulate success."""
+    calls: list[list[str]] = []
+
+    def _run(args, *, check, env, stdout, stderr):
+        calls.append(list(args))
+        return subprocess.CompletedProcess(args, 0, b"", b"")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    return calls
+
+
+def test_provision_rejects_bad_name(fake_pwd, fake_run):
+    be = system.SystemBackend()
+    with pytest.raises(ZehutError) as exc:
+        be.provision(name="WithCaps")
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "name" in exc.value.message.lower()
+
+
+def test_provision_calls_useradd_with_expected_flags(fake_pwd, fake_run):
+    fake_pwd["alice"] = 1001
+    be = system.SystemBackend()
+    result = be.provision(name="alice")
+    assert isinstance(result, ProvisionResult)
+    assert result.system_user == "alice"
+    assert result.system_uid == 1001
+    assert fake_run == [["useradd", "-m", "-U", "-s", "/bin/bash", "alice"]]
+
+
+def test_provision_pins_path(monkeypatch, fake_pwd):
+    """useradd must be invoked with PATH = /usr/sbin:/usr/bin."""
+    seen_env: dict[str, str] = {}
+
+    def _run(args, *, check, env, stdout, stderr):
+        seen_env.update(env or {})
+        return subprocess.CompletedProcess(args, 0, b"", b"")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    fake_pwd["alice"] = 1001
+    system.SystemBackend().provision(name="alice")
+    assert seen_env.get("PATH") == "/usr/sbin:/usr/bin"
+
+
+def test_provision_raises_backend_on_nonzero_useradd(monkeypatch, fake_pwd):
+    def _run(args, *, check, env, stdout, stderr):
+        return subprocess.CompletedProcess(args, 9, b"", b"useradd: user 'alice' already exists\n")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    be = system.SystemBackend()
+    with pytest.raises(ZehutError) as exc:
+        be.provision(name="alice")
+    assert exc.value.code == EXIT_BACKEND
+    assert "useradd" in exc.value.message.lower()
+
+
+def test_deprovision_calls_userdel_with_dash_r_by_default(fake_run):
+    system.SystemBackend().deprovision(name="alice", system_user="alice", keep_home=False)
+    assert fake_run == [["userdel", "-r", "alice"]]
+
+
+def test_deprovision_keep_home_drops_dash_r(fake_run):
+    system.SystemBackend().deprovision(name="alice", system_user="alice", keep_home=True)
+    assert fake_run == [["userdel", "alice"]]
+
+
+def test_deprovision_raises_backend_on_nonzero_userdel(monkeypatch):
+    def _run(args, *, check, env, stdout, stderr):
+        return subprocess.CompletedProcess(args, 6, b"", b"userdel: user 'alice' does not exist\n")
+
+    monkeypatch.setattr(system.subprocess, "run", _run)
+    with pytest.raises(ZehutError) as exc:
+        system.SystemBackend().deprovision(name="alice", system_user="alice", keep_home=False)
+    assert exc.value.code == EXIT_BACKEND
+
+
+def test_exists_consults_pwd(fake_pwd):
+    fake_pwd["alice"] = 1001
+    be = system.SystemBackend()
+    assert be.exists("alice") is True
+    assert be.exists("ghost") is False

--- a/tests/unit/test_cli_errors.py
+++ b/tests/unit/test_cli_errors.py
@@ -1,0 +1,32 @@
+"""Unit tests for zehut.cli._errors."""
+
+from __future__ import annotations
+
+from zehut.cli import _errors
+
+
+def test_exit_code_constants():
+    assert _errors.EXIT_SUCCESS == 0
+    assert _errors.EXIT_USER_ERROR == 64
+    assert _errors.EXIT_STATE == 65
+    assert _errors.EXIT_PRIVILEGE == 66
+    assert _errors.EXIT_BACKEND == 67
+    assert _errors.EXIT_CONFLICT == 68
+    assert _errors.EXIT_INTERNAL == 70
+
+
+def test_zehut_error_fields():
+    err = _errors.ZehutError(
+        code=_errors.EXIT_USER_ERROR,
+        message="no such user",
+        remediation="zehut user list",
+    )
+    assert err.code == 64
+    assert err.message == "no such user"
+    assert err.remediation == "zehut user list"
+    assert isinstance(err, Exception)
+
+
+def test_zehut_error_str_is_message():
+    err = _errors.ZehutError(code=64, message="msg", remediation="r")
+    assert str(err) == "msg"

--- a/tests/unit/test_cli_framework.py
+++ b/tests/unit/test_cli_framework.py
@@ -1,0 +1,71 @@
+"""Unit tests for zehut.cli — parser, dispatch, main()."""
+
+from __future__ import annotations
+
+import json
+
+from zehut import cli
+from zehut.cli import _errors
+
+
+def test_main_version_prints_and_returns_zero(capsys):
+    rc = cli.main(["--version"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "zehut" in cap.out
+
+
+def test_main_no_args_prints_help_and_returns_zero(capsys):
+    rc = cli.main([])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "usage:" in cap.out.lower() or "usage:" in cap.err.lower()
+
+
+def test_main_unknown_subcommand_returns_user_error_text(capsys):
+    rc = cli.main(["ghostverb"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+    assert "error:" in cap.err
+    assert "hint:" in cap.err
+
+
+def test_main_unknown_subcommand_returns_user_error_json(capsys):
+    rc = cli.main(["--json", "ghostverb"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_USER_ERROR
+    payload = json.loads(cap.err.splitlines()[-1])
+    assert payload["code"] == _errors.EXIT_USER_ERROR
+    assert "error" in payload
+    assert "hint" in payload
+
+
+def test_dispatch_wraps_unexpected_exception_as_internal(capsys):
+    def boom(_args):
+        raise RuntimeError("kaboom")
+
+    import argparse
+
+    ns = argparse.Namespace(func=boom, json=False)
+    rc = cli._dispatch(ns)
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_INTERNAL
+    assert "kaboom" in cap.err
+    # Traceback must not leak.
+    assert "Traceback" not in cap.err
+
+
+def test_dispatch_handles_zehut_error(capsys):
+    def raiser(_args):
+        raise _errors.ZehutError(
+            code=_errors.EXIT_CONFLICT, message="collision", remediation="retry"
+        )
+
+    import argparse
+
+    ns = argparse.Namespace(func=raiser, json=False)
+    rc = cli._dispatch(ns)
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_CONFLICT
+    assert "collision" in cap.err
+    assert "retry" in cap.err

--- a/tests/unit/test_cli_output.py
+++ b/tests/unit/test_cli_output.py
@@ -1,0 +1,49 @@
+"""Unit tests for zehut.cli._output."""
+
+from __future__ import annotations
+
+import json
+
+from zehut.cli import _errors, _output
+
+
+def test_emit_result_text_prints_to_stdout(capsys):
+    _output.emit_result("hello", json_mode=False)
+    cap = capsys.readouterr()
+    assert cap.out == "hello\n"
+    assert cap.err == ""
+
+
+def test_emit_result_json_prints_compact_json(capsys):
+    _output.emit_result({"a": 1}, json_mode=True)
+    cap = capsys.readouterr()
+    assert json.loads(cap.out) == {"a": 1}
+    assert cap.err == ""
+
+
+def test_emit_diagnostic_goes_to_stderr(capsys):
+    _output.emit_diagnostic("heads up", json_mode=False)
+    cap = capsys.readouterr()
+    assert cap.out == ""
+    assert "heads up" in cap.err
+
+
+def test_emit_error_text_format(capsys):
+    err = _errors.ZehutError(code=64, message="no such user", remediation="zehut user list")
+    _output.emit_error(err, json_mode=False)
+    cap = capsys.readouterr()
+    assert cap.out == ""
+    assert "error: no such user" in cap.err
+    assert "hint: zehut user list" in cap.err
+
+
+def test_emit_error_json_shape(capsys):
+    err = _errors.ZehutError(code=68, message="collision", remediation="pick a distinct --nick")
+    _output.emit_error(err, json_mode=True)
+    cap = capsys.readouterr()
+    payload = json.loads(cap.err)
+    assert payload == {
+        "error": "collision",
+        "code": 68,
+        "hint": "pick a distinct --nick",
+    }

--- a/tests/unit/test_cmd_configuration.py
+++ b/tests/unit/test_cmd_configuration.py
@@ -1,0 +1,69 @@
+"""Unit tests for ``zehut configuration ...``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, config
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "old.example.com", "--default-backend", "logical"])
+    return config_dir, state_dir
+
+
+def test_configuration_show_json(tmp_zehut, capsys):
+    rc = cli.main(["--json", "configuration", "show"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["domain"] == "old.example.com"
+    assert payload["schema_version"] == 1
+
+
+def test_configuration_show_text(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "show"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "old.example.com" in cap.out
+
+
+def test_configuration_set_domain(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "set-domain", "new.example.com"])
+    assert rc == 0
+    assert config.load().domain == "new.example.com"
+
+
+def test_configuration_set_generic(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "set", "default_backend", "system"])
+    assert rc == 0
+    assert config.load().default_backend == "system"
+
+
+def test_configuration_set_rejects_unknown_key(tmp_zehut, capsys):
+    rc = cli.main(["configuration", "set", "frobnicate", "no"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_STATE
+    assert (
+        "unknown" in cap.err.lower()
+        or "settable" in cap.err.lower()
+        or "invalid" in cap.err.lower()
+    )
+
+
+def test_configuration_set_requires_root(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["configuration", "set-domain", "nope.com"])
+    capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE

--- a/tests/unit/test_cmd_doctor.py
+++ b/tests/unit/test_cmd_doctor.py
@@ -1,0 +1,69 @@
+"""Unit tests for ``zehut doctor``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    return config_dir, state_dir
+
+
+def test_doctor_fails_when_uninitialised(tmp_zehut, capsys):
+    rc = cli.main(["--json", "doctor"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    # Expect a FAIL on config-exists check.
+    check_names = {c["name"]: c["status"] for c in payload["checks"]}
+    assert check_names["config_exists"] == "FAIL"
+    # doctor itself exits 0 — it's a report.
+    assert rc == 0
+
+
+def test_doctor_all_pass_after_init(tmp_zehut, capsys):
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    rc = cli.main(["--json", "doctor"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    statuses = {c["status"] for c in payload["checks"]}
+    assert "FAIL" not in statuses
+    assert rc == 0
+
+
+def test_doctor_reports_drift_when_system_entry_has_unknown_uid(tmp_zehut, monkeypatch, capsys):
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=5001),
+    )
+    cli.main(["user", "create", "bob", "--system"])
+
+    # Now pretend bob is gone from /etc/passwd.
+    import pwd as _pwd
+
+    def _getpwnam(name):
+        raise KeyError(name)
+
+    monkeypatch.setattr(_pwd, "getpwnam", _getpwnam)
+    rc = cli.main(["--json", "doctor"])
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    names = {c["name"]: c["status"] for c in payload["checks"]}
+    assert names["system_users_resolve"] == "FAIL"
+    assert rc == 0

--- a/tests/unit/test_cmd_globals.py
+++ b/tests/unit/test_cmd_globals.py
@@ -62,3 +62,11 @@ def test_explain_known_topic(tmp_zehut, capsys):
 def test_explain_unknown_topic(tmp_zehut, capsys):
     rc = cli.main(["explain", "frobnicate"])
     assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_explain_multiword_topic(tmp_zehut, capsys):
+    rc = cli.main(["explain", "user", "create"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    # _TOPICS["user create"] mentions useradd.
+    assert "useradd" in cap.out.lower()

--- a/tests/unit/test_cmd_globals.py
+++ b/tests/unit/test_cmd_globals.py
@@ -1,0 +1,64 @@
+"""Unit tests for the agent-first globals (learn, overview, explain)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    cli.main(["user", "create", "alice", "--nick", "Ali"])
+    return config_dir, state_dir
+
+
+def test_learn_emits_markdown_with_frontmatter(tmp_zehut, capsys):
+    rc = cli.main(["learn"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert cap.out.startswith("---\n")
+    assert "name:" in cap.out
+    assert "zehut user" in cap.out
+
+
+def test_overview_json_shape(tmp_zehut, capsys):
+    rc = cli.main(["--json", "overview"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert "config" in payload
+    assert "users" in payload
+    assert payload["config"]["domain"] == "agents.example.com"
+    assert payload["users"][0]["name"] == "alice"
+
+
+def test_overview_text(tmp_zehut, capsys):
+    rc = cli.main(["overview"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "agents.example.com" in cap.out
+    assert "alice" in cap.out
+
+
+def test_explain_known_topic(tmp_zehut, capsys):
+    rc = cli.main(["explain", "user"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "user" in cap.out.lower()
+
+
+def test_explain_unknown_topic(tmp_zehut, capsys):
+    rc = cli.main(["explain", "frobnicate"])
+    assert rc == _errors.EXIT_USER_ERROR

--- a/tests/unit/test_cmd_init.py
+++ b/tests/unit/test_cmd_init.py
@@ -1,0 +1,82 @@
+"""Unit tests for ``zehut init``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, config, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    # Pretend we are root for these tests.
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    return config_dir, state_dir
+
+
+def test_init_non_interactive_writes_both_files(tmp_zehut, capsys):
+    rc = cli.main(["init", "--domain", "agents.example.com", "--default-backend", "system"])
+    assert rc == 0
+    cfg = config.load()
+    assert cfg.domain == "agents.example.com"
+    assert cfg.default_backend == "system"
+    assert users.list_all() == []
+
+
+def test_init_refuses_when_not_root(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["init", "--domain", "x.com", "--default-backend", "logical"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE
+    assert "sudo" in cap.err
+
+
+def test_init_is_idempotent_without_force(tmp_zehut, capsys):
+    cli.main(["init", "--domain", "x.com", "--default-backend", "logical"])
+    rc = cli.main(["init", "--domain", "ignored.com", "--default-backend", "system"])
+    assert rc == 0
+    assert config.load().domain == "x.com"  # unchanged
+
+
+def test_init_force_overwrites(tmp_zehut, capsys):
+    cli.main(["init", "--domain", "x.com", "--default-backend", "logical"])
+    rc = cli.main(
+        [
+            "init",
+            "--force",
+            "--domain",
+            "new.com",
+            "--default-backend",
+            "system",
+        ]
+    )
+    assert rc == 0
+    assert config.load().domain == "new.com"
+
+
+def test_init_json_output(tmp_zehut, capsys):
+    rc = cli.main(
+        [
+            "--json",
+            "init",
+            "--domain",
+            "agents.example.com",
+            "--default-backend",
+            "system",
+        ]
+    )
+    assert rc == 0
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["domain"] == "agents.example.com"
+    assert payload["default_backend"] == "system"
+    assert payload["initialised"] is True

--- a/tests/unit/test_cmd_user_create.py
+++ b/tests/unit/test_cmd_user_create.py
@@ -1,0 +1,90 @@
+"""Unit tests for ``zehut user create``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    return config_dir, state_dir
+
+
+def test_create_logical_default(tmp_zehut, capsys):
+    rc = cli.main(["user", "create", "alice"])
+    assert rc == 0
+    recs = users.list_all()
+    assert len(recs) == 1
+    assert recs[0].name == "alice"
+    assert recs[0].backend == "logical"
+    assert recs[0].email.endswith("@agents.example.com")
+
+
+def test_create_with_explicit_system_flag(tmp_zehut, monkeypatch, capsys):
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=2001),
+    )
+    rc = cli.main(["user", "create", "bob", "--system", "--nick", "Bobby"])
+    assert rc == 0
+    rec = users.get("bob")
+    assert rec.backend == "system"
+    assert rec.nick == "Bobby"
+    assert rec.system_uid == 2001
+
+
+def test_create_system_without_root_errors(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["user", "create", "bob", "--system"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_PRIVILEGE
+    assert "sudo" in cap.err
+
+
+def test_create_duplicate_is_conflict(tmp_zehut, capsys):
+    cli.main(["user", "create", "alice"])
+    rc = cli.main(["user", "create", "alice"])
+    assert rc == _errors.EXIT_CONFLICT
+
+
+def test_create_honours_configured_default(tmp_zehut, monkeypatch, capsys):
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=2002),
+    )
+    # Flip default to system.
+    cli.main(["configuration", "set", "default_backend", "system"])
+    rc = cli.main(["user", "create", "carol"])
+    assert rc == 0
+    assert users.get("carol").backend == "system"
+
+
+def test_create_json_output(tmp_zehut, capsys):
+    rc = cli.main(["--json", "user", "create", "alice", "--about", "qa"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["name"] == "alice"
+    assert payload["about"] == "qa"
+    assert payload["backend"] == "logical"

--- a/tests/unit/test_cmd_user_create.py
+++ b/tests/unit/test_cmd_user_create.py
@@ -88,3 +88,15 @@ def test_create_json_output(tmp_zehut, capsys):
     assert payload["name"] == "alice"
     assert payload["about"] == "qa"
     assert payload["backend"] == "logical"
+
+
+def test_create_system_refuses_foreign_os_user(tmp_zehut, monkeypatch, capsys):
+    """Existing OS user not managed by zehut must NOT be silently adopted."""
+    from zehut.backend import system as system_mod
+
+    # Pretend 'bob' already exists on the OS but not in our registry.
+    monkeypatch.setattr(system_mod.SystemBackend, "exists", lambda self, name: name == "bob")
+    rc = cli.main(["user", "create", "bob", "--system"])
+    cap = capsys.readouterr()
+    assert rc == _errors.EXIT_CONFLICT
+    assert "not zehut-managed" in cap.err or "refusing to adopt" in cap.err

--- a/tests/unit/test_cmd_user_crud.py
+++ b/tests/unit/test_cmd_user_crud.py
@@ -114,3 +114,11 @@ def test_delete_system_needs_root(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
     rc = cli.main(["user", "delete", "bob"])
     assert rc == _errors.EXIT_PRIVILEGE
+
+
+def test_set_ambient_via_env_identity(tmp_zehut_with_alice, monkeypatch, capsys):
+    """`zehut user set nick=X` should resolve ambient via $ZEHUT_IDENTITY."""
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    rc = cli.main(["user", "set", "nick=Alicia"])
+    assert rc == 0
+    assert users.get("alice").nick == "Alicia"

--- a/tests/unit/test_cmd_user_crud.py
+++ b/tests/unit/test_cmd_user_crud.py
@@ -1,0 +1,116 @@
+"""Unit tests for ``zehut user list|show|set|delete``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli, users
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut_with_alice(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    cli.main(["user", "create", "alice", "--nick", "Ali", "--about", "qa"])
+    return config_dir, state_dir
+
+
+def test_list_json(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["--json", "user", "list"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert isinstance(payload, list)
+    assert payload[0]["name"] == "alice"
+
+
+def test_list_text(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "list"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+    assert "logical" in cap.out
+
+
+def test_show_by_name(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "show", "alice"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+    assert "Ali" in cap.out
+
+
+def test_show_unknown_user(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "show", "ghost"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_set_nick_by_name(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "nick=Alicia"])
+    assert rc == 0
+    assert users.get("alice").nick == "Alicia"
+
+
+def test_set_multiple_fields(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "nick=A", "about=new"])
+    assert rc == 0
+    rec = users.get("alice")
+    assert rec.nick == "A"
+    assert rec.about == "new"
+
+
+def test_set_rejects_unknown_key(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "email=other@x.com"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_set_bad_assignment_syntax(tmp_zehut_with_alice, capsys):
+    rc = cli.main(["user", "set", "alice", "nick Alicia"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_delete_logical_no_root_needed(tmp_zehut_with_alice, monkeypatch, capsys):
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["user", "delete", "alice"])
+    assert rc == 0
+    assert users.list_all() == []
+
+
+def test_delete_system_needs_root(tmp_path, monkeypatch, capsys):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "system"])
+
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=3001),
+    )
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "deprovision",
+        lambda self, *, name, system_user, keep_home: None,
+    )
+    cli.main(["user", "create", "bob", "--system"])
+
+    # Drop root for the delete.
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 1000)
+    rc = cli.main(["user", "delete", "bob"])
+    assert rc == _errors.EXIT_PRIVILEGE

--- a/tests/unit/test_cmd_user_switch.py
+++ b/tests/unit/test_cmd_user_switch.py
@@ -1,0 +1,94 @@
+"""Unit tests for ``zehut user switch`` / ``whoami`` / ``current``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import cli
+from zehut.cli import _errors
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    monkeypatch.setattr("zehut.privilege.os.geteuid", lambda: 0)
+    cli.main(["init", "--domain", "agents.example.com", "--default-backend", "logical"])
+    return config_dir, state_dir
+
+
+def test_switch_logical_prints_export(tmp_zehut, capsys):
+    cli.main(["user", "create", "alice"])
+    capsys.readouterr()  # flush create output
+    rc = cli.main(["user", "switch", "alice"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert cap.out.strip() == "export ZEHUT_IDENTITY=alice"
+
+
+def test_switch_unknown_user(tmp_zehut, capsys):
+    rc = cli.main(["user", "switch", "ghost"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_switch_system_execs_sudo(tmp_zehut, monkeypatch, capsys):
+    from zehut.backend import system as system_mod
+    from zehut.backend.base import ProvisionResult
+
+    monkeypatch.setattr(
+        system_mod.SystemBackend,
+        "provision",
+        lambda self, *, name: ProvisionResult(system_user=name, system_uid=4001),
+    )
+    cli.main(["user", "create", "bob", "--system"])
+
+    recorded: list[list[str]] = []
+
+    def fake_execvp(prog, argv):
+        recorded.append([prog, *argv[1:]])
+        raise SystemExit(0)
+
+    monkeypatch.setattr("os.execvp", fake_execvp)
+    rc = cli.main(["user", "switch", "bob"])
+    # The test harness's main() catches SystemExit and returns the code as int.
+    assert rc == 0
+    assert recorded == [["sudo", "-u", "bob", "-i"]]
+
+
+def test_whoami_none_when_no_ambient(tmp_zehut, monkeypatch, capsys):
+    monkeypatch.delenv("ZEHUT_IDENTITY", raising=False)
+    rc = cli.main(["user", "whoami"])
+    assert rc == _errors.EXIT_USER_ERROR
+
+
+def test_whoami_env_fallback(tmp_zehut, monkeypatch, capsys):
+    cli.main(["user", "create", "alice"])
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    rc = cli.main(["user", "whoami"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out
+
+
+def test_whoami_json(tmp_zehut, monkeypatch, capsys):
+    cli.main(["user", "create", "alice"])
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    assert cli.main(["--json", "user", "whoami"]) == 0
+    cap = capsys.readouterr()
+    payload = json.loads(cap.out.splitlines()[-1])
+    assert payload["name"] == "alice"
+
+
+def test_current_is_an_alias_for_whoami(tmp_zehut, monkeypatch, capsys):
+    cli.main(["user", "create", "alice"])
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    rc = cli.main(["user", "current"])
+    cap = capsys.readouterr()
+    assert rc == 0
+    assert "alice" in cap.out

--- a/tests/unit/test_cmd_user_switch.py
+++ b/tests/unit/test_cmd_user_switch.py
@@ -47,18 +47,25 @@ def test_switch_system_execs_sudo(tmp_zehut, monkeypatch, capsys):
         lambda self, *, name: ProvisionResult(system_user=name, system_uid=4001),
     )
     cli.main(["user", "create", "bob", "--system"])
+    capsys.readouterr()  # flush create output
 
     recorded: list[list[str]] = []
 
-    def fake_execvp(prog, argv):
+    def fake_execv(prog, argv):
         recorded.append([prog, *argv[1:]])
         raise SystemExit(0)
 
-    monkeypatch.setattr("os.execvp", fake_execvp)
+    # Force shutil.which to return a predictable path so the assertion
+    # doesn't depend on the test host's sudo location.
+    import shutil as _shutil
+
+    monkeypatch.setattr(_shutil, "which", lambda name: "/usr/bin/sudo" if name == "sudo" else None)
+    monkeypatch.setattr("os.execv", fake_execv)
+
     rc = cli.main(["user", "switch", "bob"])
     # The test harness's main() catches SystemExit and returns the code as int.
     assert rc == 0
-    assert recorded == [["sudo", "-u", "bob", "-i"]]
+    assert recorded == [["/usr/bin/sudo", "-u", "bob", "-i"]]
 
 
 def test_whoami_none_when_no_ambient(tmp_zehut, monkeypatch, capsys):

--- a/tests/unit/test_cmd_user_switch.py
+++ b/tests/unit/test_cmd_user_switch.py
@@ -55,11 +55,19 @@ def test_switch_system_execs_sudo(tmp_zehut, monkeypatch, capsys):
         recorded.append([prog, *argv[1:]])
         raise SystemExit(0)
 
-    # Force shutil.which to return a predictable path so the assertion
-    # doesn't depend on the test host's sudo location.
-    import shutil as _shutil
+    # The command now uses a hardcoded trusted path list (/usr/bin/sudo
+    # then /bin/sudo). Make the first candidate look present and executable.
+    import os as _os
 
-    monkeypatch.setattr(_shutil, "which", lambda name: "/usr/bin/sudo" if name == "sudo" else None)
+    real_isfile = _os.path.isfile
+    real_access = _os.access
+    monkeypatch.setattr(
+        _os.path, "isfile", lambda p: True if p == "/usr/bin/sudo" else real_isfile(p)
+    )
+    monkeypatch.setattr(
+        _os, "access",
+        lambda p, mode: True if p == "/usr/bin/sudo" else real_access(p, mode),
+    )
     monkeypatch.setattr("os.execv", fake_execv)
 
     rc = cli.main(["user", "switch", "bob"])

--- a/tests/unit/test_cmd_user_switch.py
+++ b/tests/unit/test_cmd_user_switch.py
@@ -65,7 +65,8 @@ def test_switch_system_execs_sudo(tmp_zehut, monkeypatch, capsys):
         _os.path, "isfile", lambda p: True if p == "/usr/bin/sudo" else real_isfile(p)
     )
     monkeypatch.setattr(
-        _os, "access",
+        _os,
+        "access",
         lambda p, mode: True if p == "/usr/bin/sudo" else real_access(p, mode),
     )
     monkeypatch.setattr("os.execv", fake_execv)

--- a/tests/unit/test_cmd_user_switch.py
+++ b/tests/unit/test_cmd_user_switch.py
@@ -71,9 +71,12 @@ def test_switch_system_execs_sudo(tmp_zehut, monkeypatch, capsys):
     )
     monkeypatch.setattr("os.execv", fake_execv)
 
-    rc = cli.main(["user", "switch", "bob"])
-    # The test harness's main() catches SystemExit and returns the code as int.
-    assert rc == 0
+    # main() no longer catches SystemExit (removed to clear Sonar S5754);
+    # os.execv in production replaces the process and never returns, so the
+    # test's SystemExit-raising mock accurately represents that contract.
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["user", "switch", "bob"])
+    assert excinfo.value.code == 0
     assert recorded == [["/usr/bin/sudo", "-u", "bob", "-i"]]
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for zehut.config."""
+
+from __future__ import annotations
+
+import pytest
+
+from zehut import config
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    return config_dir, state_dir
+
+
+def test_default_config_values():
+    cfg = config.Config.default(domain="agents.example.com", backend="system")
+    assert cfg.schema_version == 1
+    assert cfg.domain == "agents.example.com"
+    assert cfg.default_backend == "system"
+    assert cfg.email_pattern == "{name}"
+    assert cfg.email_collision == "suffix"
+
+
+def test_save_and_load_roundtrip(tmp_zehut):
+    cfg = config.Config.default(domain="x.example.com", backend="logical")
+    config.save(cfg)
+    loaded = config.load()
+    assert loaded == cfg
+
+
+def test_save_writes_expected_toml(tmp_zehut):
+    config_dir, _ = tmp_zehut
+    cfg = config.Config.default(domain="agents.example.com", backend="system")
+    config.save(cfg)
+    text = (config_dir / "config.toml").read_text()
+    assert "schema_version = 1" in text
+    assert 'domain = "agents.example.com"' in text
+    assert 'backend = "system"' in text
+
+
+def test_load_missing_raises_state_error(tmp_zehut):
+    with pytest.raises(config.ConfigStateError) as exc:
+        config.load()
+    assert "not initialized" in str(exc.value).lower() or "missing" in str(exc.value).lower()
+
+
+def test_load_wrong_schema_version_raises(tmp_zehut):
+    config_dir, _ = tmp_zehut
+    (config_dir / "config.toml").write_text(
+        "schema_version = 2\n"
+        '[defaults]\nbackend = "system"\n'
+        '[email]\ndomain = "x.example.com"\npattern = "{name}"\ncollision = "suffix"\n'
+    )
+    with pytest.raises(config.ConfigStateError) as exc:
+        config.load()
+    assert "schema" in str(exc.value).lower()
+
+
+def test_load_rejects_unknown_backend(tmp_zehut):
+    config_dir, _ = tmp_zehut
+    (config_dir / "config.toml").write_text(
+        "schema_version = 1\n"
+        '[defaults]\nbackend = "wat"\n'
+        '[email]\ndomain = "x.example.com"\npattern = "{name}"\ncollision = "suffix"\n'
+    )
+    with pytest.raises(config.ConfigStateError):
+        config.load()
+
+
+def test_set_key_updates_value(tmp_zehut):
+    cfg = config.Config.default(domain="x.example.com", backend="system")
+    config.save(cfg)
+    config.set_key("domain", "agents.new.com")
+    reloaded = config.load()
+    assert reloaded.domain == "agents.new.com"
+
+
+def test_set_key_rejects_unknown_key(tmp_zehut):
+    cfg = config.Config.default(domain="x.example.com", backend="system")
+    config.save(cfg)
+    with pytest.raises(config.ConfigStateError):
+        config.set_key("not_a_real_key", "whatever")

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -1,0 +1,107 @@
+"""Unit tests for zehut.fs — paths, locking, atomic writes."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from zehut import fs
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    return config_dir, state_dir
+
+
+def test_default_paths_without_env(monkeypatch):
+    monkeypatch.delenv("ZEHUT_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("ZEHUT_STATE_DIR", raising=False)
+    assert fs.config_dir() == Path("/etc/zehut")
+    assert fs.state_dir() == Path("/var/lib/zehut")
+    assert fs.config_file() == Path("/etc/zehut/config.toml")
+    assert fs.users_file() == Path("/var/lib/zehut/users.json")
+    assert fs.lock_file() == Path("/var/lib/zehut/.lock")
+
+
+def test_paths_honour_env_overrides(tmp_zehut):
+    config_dir, state_dir = tmp_zehut
+    assert fs.config_dir() == config_dir
+    assert fs.state_dir() == state_dir
+    assert fs.config_file() == config_dir / "config.toml"
+    assert fs.users_file() == state_dir / "users.json"
+
+
+def test_atomic_write_text_creates_file_with_content(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+    fs.atomic_write_text(target, "hello\n", mode=0o644)
+    assert target.read_text() == "hello\n"
+    assert oct(target.stat().st_mode & 0o777) == oct(0o644)
+
+
+def test_atomic_write_text_overwrites(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+    target.write_text("old")
+    fs.atomic_write_text(target, "new", mode=0o644)
+    assert target.read_text() == "new"
+
+
+def test_atomic_write_text_leaves_no_tmp_on_success(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+    fs.atomic_write_text(target, "ok", mode=0o644)
+    tmps = [p for p in state_dir.iterdir() if p.name.startswith(".x.txt.")]
+    assert tmps == []
+
+
+def test_exclusive_lock_blocks_concurrent_writer(tmp_zehut):
+    _, state_dir = tmp_zehut
+    lock_path = state_dir / ".lock"
+    lock_path.touch()
+    observed: list[str] = []
+
+    def worker(tag: str, hold_for: float):
+        import time
+
+        with fs.exclusive_lock(lock_path):
+            observed.append(f"{tag}-enter")
+            time.sleep(hold_for)
+            observed.append(f"{tag}-leave")
+
+    t1 = threading.Thread(target=worker, args=("a", 0.2))
+    t2 = threading.Thread(target=worker, args=("b", 0.0))
+    t1.start()
+    # give t1 time to acquire the lock before t2 races
+    import time as _time
+
+    _time.sleep(0.05)
+    t2.start()
+    t1.join()
+    t2.join()
+
+    # a must fully enter and leave before b enters
+    assert observed == ["a-enter", "a-leave", "b-enter", "b-leave"]
+
+
+def test_read_json_roundtrip(tmp_zehut):
+    _, state_dir = tmp_zehut
+    target = state_dir / "data.json"
+    payload = {"schema_version": 1, "users": []}
+    fs.atomic_write_text(target, json.dumps(payload), mode=0o644)
+    assert fs.read_json(target) == payload
+
+
+def test_read_json_missing_raises_filenotfound(tmp_zehut):
+    _, state_dir = tmp_zehut
+    with pytest.raises(FileNotFoundError):
+        fs.read_json(state_dir / "nope.json")

--- a/tests/unit/test_fs.py
+++ b/tests/unit/test_fs.py
@@ -38,6 +38,7 @@ def test_paths_honour_env_overrides(tmp_zehut):
     assert fs.state_dir() == state_dir
     assert fs.config_file() == config_dir / "config.toml"
     assert fs.users_file() == state_dir / "users.json"
+    assert fs.lock_file() == state_dir / ".lock"
 
 
 def test_atomic_write_text_creates_file_with_content(tmp_zehut):
@@ -64,32 +65,50 @@ def test_atomic_write_text_leaves_no_tmp_on_success(tmp_zehut):
     assert tmps == []
 
 
+def test_atomic_write_text_cleans_up_tmp_on_failure(tmp_zehut, monkeypatch):
+    _, state_dir = tmp_zehut
+    target = state_dir / "x.txt"
+
+    def _boom(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(fs.os, "replace", _boom)
+    with pytest.raises(OSError, match="simulated replace failure"):
+        fs.atomic_write_text(target, "payload", mode=0o644)
+
+    # Neither the target nor any .x.txt.*.tmp sibling should remain.
+    assert not target.exists()
+    tmps = [p for p in state_dir.iterdir() if p.name.startswith(".x.txt.")]
+    assert tmps == []
+
+
 def test_exclusive_lock_blocks_concurrent_writer(tmp_zehut):
+    import time
+
     _, state_dir = tmp_zehut
     lock_path = state_dir / ".lock"
     lock_path.touch()
     observed: list[str] = []
+    first_locked = threading.Event()
 
-    def worker(tag: str, hold_for: float):
-        import time
-
+    def worker(tag: str, hold_for: float, signal_when_locked: bool):
         with fs.exclusive_lock(lock_path):
+            if signal_when_locked:
+                first_locked.set()
             observed.append(f"{tag}-enter")
             time.sleep(hold_for)
             observed.append(f"{tag}-leave")
 
-    t1 = threading.Thread(target=worker, args=("a", 0.2))
-    t2 = threading.Thread(target=worker, args=("b", 0.0))
+    t1 = threading.Thread(target=worker, args=("a", 0.2, True))
     t1.start()
-    # give t1 time to acquire the lock before t2 races
-    import time as _time
-
-    _time.sleep(0.05)
+    # Wait until t1 has actually acquired the lock before starting t2, so
+    # the assertion doesn't depend on wall-clock scheduling.
+    assert first_locked.wait(timeout=2.0), "t1 failed to acquire lock within timeout"
+    t2 = threading.Thread(target=worker, args=("b", 0.0, False))
     t2.start()
     t1.join()
     t2.join()
 
-    # a must fully enter and leave before b enters
     assert observed == ["a-enter", "a-leave", "b-enter", "b-leave"]
 
 

--- a/tests/unit/test_privilege.py
+++ b/tests/unit/test_privilege.py
@@ -45,3 +45,9 @@ def test_sudo_command_falls_back_to_zehut_when_not_found(monkeypatch):
     monkeypatch.setattr(privilege, "_zehut_binary", lambda: None)
     cmd = privilege.sudo_command(["doctor"])
     assert cmd == "sudo zehut doctor"
+
+
+def test_assume_root_env_bypasses_real_geteuid(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 1000)
+    monkeypatch.setenv("ZEHUT_ASSUME_ROOT", "1")
+    assert privilege.is_root() is True

--- a/tests/unit/test_privilege.py
+++ b/tests/unit/test_privilege.py
@@ -1,0 +1,47 @@
+"""Unit tests for zehut.privilege."""
+
+from __future__ import annotations
+
+import pytest
+
+from zehut import privilege
+
+
+def test_is_root_true(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 0)
+    assert privilege.is_root() is True
+
+
+def test_is_root_false(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 1000)
+    assert privilege.is_root() is False
+
+
+def test_require_root_passes_when_root(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 0)
+    # Should not raise
+    privilege.require_root(action="do a thing")
+
+
+def test_require_root_raises_when_not_root(monkeypatch):
+    monkeypatch.setattr(privilege.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(privilege, "_zehut_binary", lambda: "/home/x/.local/bin/zehut")
+    with pytest.raises(privilege.PrivilegeError) as exc:
+        privilege.require_root(
+            action="create a system user", argv=["user", "create", "alice", "--system"]
+        )
+    assert "sudo" in exc.value.remediation
+    assert "/home/x/.local/bin/zehut" in exc.value.remediation
+    assert "user create alice --system" in exc.value.remediation
+
+
+def test_sudo_command_uses_full_path(monkeypatch):
+    monkeypatch.setattr(privilege, "_zehut_binary", lambda: "/opt/zehut/bin/zehut")
+    cmd = privilege.sudo_command(["user", "create", "alice"])
+    assert cmd == "sudo /opt/zehut/bin/zehut user create alice"
+
+
+def test_sudo_command_falls_back_to_zehut_when_not_found(monkeypatch):
+    monkeypatch.setattr(privilege, "_zehut_binary", lambda: None)
+    cmd = privilege.sudo_command(["doctor"])
+    assert cmd == "sudo zehut doctor"

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -146,3 +146,58 @@ def test_ulid_is_26_crockford_chars(tmp_zehut):
     u = users._generate_ulid()
     assert len(u) == 26
     assert set(u).issubset(set("0123456789ABCDEFGHJKMNPQRSTVWXYZ"))
+
+
+# --- ambient_name -------------------------------------------------------------
+
+
+def test_ambient_name_none_when_no_match(tmp_zehut, monkeypatch):
+    # No records; OS user doesn't match; env var unset.
+    monkeypatch.delenv("ZEHUT_IDENTITY", raising=False)
+    assert users.ambient_name() is None
+
+
+def test_ambient_name_matches_system_backed_os_user(tmp_zehut, monkeypatch):
+    import types
+
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    # Seed a system-backed record by poking the registry directly.
+    doc = users._load_raw_unlocked()
+    doc["users"].append(
+        {
+            "id": "01FAKE0000000000000000000A",
+            "name": "bob",
+            "nick": None,
+            "about": None,
+            "email": "bob@agents.example.com",
+            "backend": "system",
+            "system_user": "bob",
+            "system_uid": 1234,
+            "created_at": "2026-04-24T00:00:00Z",
+            "updated_at": "2026-04-24T00:00:00Z",
+        }
+    )
+    users._save_raw(doc)
+    monkeypatch.setattr(
+        users.pwd,
+        "getpwuid",
+        lambda uid: types.SimpleNamespace(pw_name="bob", pw_uid=1234),
+    )
+    monkeypatch.delenv("ZEHUT_IDENTITY", raising=False)
+    assert users.ambient_name() == "bob"
+
+
+def test_ambient_name_env_var_fallback(tmp_zehut, monkeypatch):
+    import types
+
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    # OS user does not match any zehut record.
+    monkeypatch.setattr(
+        users.pwd,
+        "getpwuid",
+        lambda uid: types.SimpleNamespace(pw_name="nobody", pw_uid=65534),
+    )
+    monkeypatch.setenv("ZEHUT_IDENTITY", "alice")
+    assert users.ambient_name() == "alice"

--- a/tests/unit/test_users.py
+++ b/tests/unit/test_users.py
@@ -1,0 +1,148 @@
+"""Unit tests for zehut.users — registry CRUD + email generation."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from zehut import config, fs, users
+from zehut.backend.logical import LogicalBackend
+from zehut.cli._errors import EXIT_CONFLICT, EXIT_STATE, EXIT_USER_ERROR, ZehutError
+
+
+@pytest.fixture
+def tmp_zehut(tmp_path, monkeypatch):
+    config_dir = tmp_path / "etc-zehut"
+    state_dir = tmp_path / "var-lib-zehut"
+    monkeypatch.setenv("ZEHUT_CONFIG_DIR", str(config_dir))
+    monkeypatch.setenv("ZEHUT_STATE_DIR", str(state_dir))
+    config_dir.mkdir()
+    state_dir.mkdir()
+    cfg = config.Config.default(domain="agents.example.com", backend="logical")
+    config.save(cfg)
+    users.init_registry()
+    return config_dir, state_dir
+
+
+# --- email generation ---------------------------------------------------------
+
+
+def test_render_email_single_token(tmp_zehut):
+    assert users.render_email("{name}", name="alice", nick="", domain="x.com") == "alice@x.com"
+
+
+def test_render_email_nick_fallback_operator(tmp_zehut):
+    # Nick present → use it.
+    assert (
+        users.render_email("{nick|name}", name="alice", nick="ali", domain="x.com") == "ali@x.com"
+    )
+    # Nick empty → fall back to name.
+    assert users.render_email("{nick|name}", name="alice", nick="", domain="x.com") == "alice@x.com"
+
+
+def test_render_email_id_short_token(tmp_zehut):
+    email = users.render_email(
+        "{id-short}", name="alice", nick="", domain="x.com", id_short="01HYA9ZZ"
+    )
+    assert email == "01HYA9ZZ@x.com"
+
+
+def test_render_email_empty_result_raises(tmp_zehut):
+    with pytest.raises(ZehutError) as exc:
+        users.render_email("{nick}", name="alice", nick="", domain="x.com")
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+# --- registry CRUD ------------------------------------------------------------
+
+
+def test_init_registry_creates_empty_file(tmp_zehut):
+    _, state_dir = tmp_zehut
+    path = state_dir / "users.json"
+    assert path.exists()
+    assert fs.read_json(path) == {"schema_version": 1, "users": []}
+
+
+def test_add_then_list(tmp_zehut):
+    be = LogicalBackend()
+    rec = users.add(name="alice", nick="Ali", about="qa", backend_name="logical", backend=be)
+    assert rec.name == "alice"
+    assert rec.backend == "logical"
+    assert rec.email.endswith("@agents.example.com")
+    lst = users.list_all()
+    assert len(lst) == 1
+    assert lst[0].name == "alice"
+
+
+def test_add_duplicate_name_raises_conflict(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    with pytest.raises(ZehutError) as exc:
+        users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    assert exc.value.code == EXIT_CONFLICT
+
+
+def test_add_email_collision_appends_suffix(tmp_zehut, monkeypatch):
+    # Force every render to produce "ali@..." so collisions happen.
+    monkeypatch.setattr(users, "render_email", lambda pattern, **kw: f"ali@{kw['domain']}")
+    be = LogicalBackend()
+    r1 = users.add(name="alice", nick="Ali", about=None, backend_name="logical", backend=be)
+    r2 = users.add(name="alice2", nick="Ali", about=None, backend_name="logical", backend=be)
+    assert r1.email == "ali@agents.example.com"
+    assert r2.email == "ali-2@agents.example.com"
+
+
+def test_get_returns_record(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    rec = users.get("alice")
+    assert rec.name == "alice"
+
+
+def test_get_missing_raises_user_error(tmp_zehut):
+    with pytest.raises(ZehutError) as exc:
+        users.get("ghost")
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_update_sets_nick_and_about(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    users.update("alice", nick="Ali", about="qa agent")
+    rec = users.get("alice")
+    assert rec.nick == "Ali"
+    assert rec.about == "qa agent"
+
+
+def test_update_rejects_immutable_keys(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    with pytest.raises(ZehutError) as exc:
+        users.update("alice", email="other@x.com")
+    assert exc.value.code == EXIT_USER_ERROR
+
+
+def test_remove_drops_record(tmp_zehut):
+    be = LogicalBackend()
+    users.add(name="alice", nick=None, about=None, backend_name="logical", backend=be)
+    users.remove("alice", backend=be, keep_home=False)
+    assert users.list_all() == []
+
+
+def test_registry_load_rejects_wrong_schema(tmp_zehut):
+    _, state_dir = tmp_zehut
+    fs.atomic_write_text(
+        state_dir / "users.json",
+        json.dumps({"schema_version": 2, "users": []}),
+        mode=0o644,
+    )
+    with pytest.raises(ZehutError) as exc:
+        users.list_all()
+    assert exc.value.code == EXIT_STATE
+
+
+def test_ulid_is_26_crockford_chars(tmp_zehut):
+    u = users._generate_ulid()
+    assert len(u) == 26
+    assert set(u).issubset(set("0123456789ABCDEFGHJKMNPQRSTVWXYZ"))

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,646 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "flake8-bandit"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bandit" },
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/1c/4f66a7a52a246d6c64312b5c40da3af3630cd60b27af81b137796af3c0bc/flake8_bandit-4.1.1.tar.gz", hash = "sha256:068e09287189cbfd7f986e92605adea2067630b75380c6b5733dab7d87f9a84e", size = 5403, upload-time = "2022-08-29T13:48:41.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/5f/55bab0ac89f9ad9f4c6e38087faa80c252daec4ccb7776b4dac216ca9e3f/flake8_bandit-4.1.1-py3-none-any.whl", hash = "sha256:4c8a53eb48f23d4ef1e59293657181a3c989d0077c9952717e98a0eace43e06d", size = 4828, upload-time = "2022-08-29T13:48:39.737Z" },
+]
+
+[[package]]
+name = "flake8-bugbear"
+version = "25.11.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "flake8" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/2a996e2fca7810bd1b031901d65fc4292630895afcb946ebd00568bdc669/flake8_bugbear-25.11.29.tar.gz", hash = "sha256:b5d06710f3d26e595541ad303ad4d5cb52578bd4bccbb2c2c0b2c72e243dafc8", size = 84896, upload-time = "2025-11-29T20:51:57.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/42/c18f199780d99a6f6a64c4a36f4ad28a445d9e11968a6025b21d0c8b6802/flake8_bugbear-25.11.29-py3-none-any.whl", hash = "sha256:9bf15e2970e736d2340da4c0a70493db964061c9c38f708cfe1f7b2d87392298", size = 37861, upload-time = "2025-11-29T20:51:56.439Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]
+
+[[package]]
+name = "zehut"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "bandit" },
+    { name = "black" },
+    { name = "coverage" },
+    { name = "flake8" },
+    { name = "flake8-bandit" },
+    { name = "flake8-bugbear" },
+    { name = "isort" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.7.5" },
+    { name = "black", specifier = ">=23.7.0" },
+    { name = "coverage", specifier = ">=7.2.0" },
+    { name = "flake8", specifier = ">=6.1" },
+    { name = "flake8-bandit", specifier = ">=4.1.1" },
+    { name = "flake8-bugbear", specifier = ">=23.7.10" },
+    { name = "isort", specifier = ">=5.12.0" },
+    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "pylint", specifier = ">=2.17.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-xdist", specifier = ">=3.0" },
+]

--- a/zehut/__init__.py
+++ b/zehut/__init__.py
@@ -1,0 +1,17 @@
+"""zehut — agents-first identity layer.
+
+Exposes the package version via importlib.metadata so pyproject.toml is the
+single source of truth. No other top-level re-exports; callers import from
+submodules directly (`from zehut.users import Registry`, etc.).
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("zehut")
+except PackageNotFoundError:  # pragma: no cover — only hit in uninstalled dev trees
+    __version__ = "0.0.0+local"
+
+__all__ = ["__version__"]

--- a/zehut/__main__.py
+++ b/zehut/__main__.py
@@ -1,0 +1,10 @@
+"""Allow ``python -m zehut`` to reach the CLI entry point."""
+
+from __future__ import annotations
+
+import sys
+
+from zehut.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zehut/backend/__init__.py
+++ b/zehut/backend/__init__.py
@@ -1,0 +1,12 @@
+"""Backend strategies — ``system`` and ``logical``.
+
+Both share the :class:`~zehut.backend.base.Backend` ABC so
+``zehut.users`` can treat them uniformly.
+"""
+
+from __future__ import annotations
+
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.backend.logical import LogicalBackend
+
+__all__ = ["Backend", "ProvisionResult", "LogicalBackend"]

--- a/zehut/backend/__init__.py
+++ b/zehut/backend/__init__.py
@@ -1,12 +1,9 @@
-"""Backend strategies — ``system`` and ``logical``.
-
-Both share the :class:`~zehut.backend.base.Backend` ABC so
-``zehut.users`` can treat them uniformly.
-"""
+"""Backend strategies — ``system`` and ``logical``."""
 
 from __future__ import annotations
 
 from zehut.backend.base import Backend, ProvisionResult
 from zehut.backend.logical import LogicalBackend
+from zehut.backend.system import SystemBackend
 
-__all__ = ["Backend", "ProvisionResult", "LogicalBackend"]
+__all__ = ["Backend", "ProvisionResult", "LogicalBackend", "SystemBackend"]

--- a/zehut/backend/base.py
+++ b/zehut/backend/base.py
@@ -1,0 +1,32 @@
+"""Backend ABC and shared types.
+
+A backend encapsulates OS-level identity plumbing: creation, deletion,
+existence checks. ``zehut.users`` owns the registry (metadata) and calls
+into a backend for the OS side.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProvisionResult:
+    """Outcome of a successful provision."""
+
+    system_user: str | None
+    system_uid: int | None
+
+
+class Backend(ABC):
+    """Abstract backend interface."""
+
+    @abstractmethod
+    def provision(self, *, name: str) -> ProvisionResult: ...
+
+    @abstractmethod
+    def deprovision(self, *, name: str, system_user: str | None, keep_home: bool) -> None: ...
+
+    @abstractmethod
+    def exists(self, name: str) -> bool: ...

--- a/zehut/backend/logical.py
+++ b/zehut/backend/logical.py
@@ -1,0 +1,22 @@
+"""Logical (metadata-only) backend.
+
+A logical identity has no OS account; it exists purely in the zehut
+registry. ``provision`` and ``deprovision`` are no-ops at the OS layer;
+``exists`` always returns ``False`` because we define "exists" as "has an
+OS presence", which logical identities never do.
+"""
+
+from __future__ import annotations
+
+from zehut.backend.base import Backend, ProvisionResult
+
+
+class LogicalBackend(Backend):
+    def provision(self, *, name: str) -> ProvisionResult:
+        return ProvisionResult(system_user=None, system_uid=None)
+
+    def deprovision(self, *, name: str, system_user: str | None, keep_home: bool) -> None:
+        return None
+
+    def exists(self, name: str) -> bool:
+        return False

--- a/zehut/backend/system.py
+++ b/zehut/backend/system.py
@@ -1,0 +1,77 @@
+"""System backend — wraps ``useradd`` and ``userdel``.
+
+The only place in zehut that invokes these binaries. ``PATH`` is pinned to
+``/usr/sbin:/usr/bin`` on every call so malicious shadowing in a
+privileged caller's environment cannot redirect us to a different binary.
+Names are validated against a conservative POSIX-shaped pattern before
+any subprocess is spawned.
+"""
+
+from __future__ import annotations
+
+import pwd
+import re
+import subprocess
+
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.cli._errors import EXIT_BACKEND, EXIT_USER_ERROR, ZehutError
+
+_NAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+_SAFE_PATH = "/usr/sbin:/usr/bin"
+
+
+def _validate_name(name: str) -> None:
+    if not _NAME_RE.match(name):
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(f"invalid user name {name!r}: must match ^[a-z_][a-z0-9_-]{{0,31}}$"),
+            remediation="pick a POSIX-compliant user name (lowercase, digits, dash, underscore)",
+        )
+
+
+def _run(cmd: list[str], *, what: str) -> None:
+    result = subprocess.run(
+        cmd,
+        check=False,
+        env={"PATH": _SAFE_PATH, "LC_ALL": "C"},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise ZehutError(
+            code=EXIT_BACKEND,
+            message=f"{what} failed (exit {result.returncode}): {stderr or '<no output>'}",
+            remediation=f"inspect system logs and re-run {cmd[0]} manually to reproduce",
+        )
+
+
+class SystemBackend(Backend):
+    def provision(self, *, name: str) -> ProvisionResult:
+        _validate_name(name)
+        _run(["useradd", "-m", "-U", "-s", "/bin/bash", name], what="useradd")
+        try:
+            entry = pwd.getpwnam(name)
+        except KeyError as err:  # pragma: no cover — very unlikely after successful useradd
+            raise ZehutError(
+                code=EXIT_BACKEND,
+                message=f"useradd succeeded but {name!r} not found in pwd database",
+                remediation="run 'getent passwd' and 'zehut doctor' to diagnose",
+            ) from err
+        return ProvisionResult(system_user=entry.pw_name, system_uid=entry.pw_uid)
+
+    def deprovision(self, *, name: str, system_user: str | None, keep_home: bool) -> None:
+        target = system_user or name
+        _validate_name(target)
+        cmd = ["userdel"]
+        if not keep_home:
+            cmd.append("-r")
+        cmd.append(target)
+        _run(cmd, what="userdel")
+
+    def exists(self, name: str) -> bool:
+        try:
+            pwd.getpwnam(name)
+        except KeyError:
+            return False
+        return True

--- a/zehut/backend/system.py
+++ b/zehut/backend/system.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pwd
 import re
-import subprocess
+import subprocess  # nosec B404
 
 from zehut.backend.base import Backend, ProvisionResult
 from zehut.cli._errors import EXIT_BACKEND, EXIT_USER_ERROR, ZehutError
@@ -30,7 +30,9 @@ def _validate_name(name: str) -> None:
 
 
 def _run(cmd: list[str], *, what: str) -> None:
-    result = subprocess.run(
+    # Trusted callsite: cmd[0] is a hard-coded binary name (useradd/userdel)
+    # and cmd[1:] values are pre-validated against _NAME_RE. PATH is pinned.
+    result = subprocess.run(  # nosec B603
         cmd,
         check=False,
         env={"PATH": _SAFE_PATH, "LC_ALL": "C"},

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -74,9 +74,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     # parser_class propagates to every subparser so .error() routes through
     # _ZehutArgumentParser everywhere.
-    parser.add_subparsers(dest="command", parser_class=_ZehutArgumentParser)
-    # Noun groups register here in later tasks (user, configuration),
-    # along with globals (init, doctor, learn, overview, explain).
+    sub = parser.add_subparsers(dest="command", parser_class=_ZehutArgumentParser)
+
+    # Lazy imports avoid circulars (command modules import cli._output etc.).
+    from zehut.cli._commands import init as _init_cmd  # noqa: WPS433
+
+    _init_cmd.register(sub)
+
+    # More noun groups and globals register here in later tasks.
     return parser
 
 

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -1,26 +1,124 @@
-"""CLI entry point — Task 1 placeholder.
+"""Unified CLI entry point — parser, dispatcher, error routing.
 
-This module is fleshed out in Task 6 (parser + dispatch + error routing).
-For now it exists so ``uv run zehut --version`` and ``python -m zehut`` work.
+Mirrors ``afi-cli``'s ``afi.cli`` module:
+
+* Every argparse error routes through :func:`_output.emit_error` via a
+  subclassed parser. This produces structured errors (text or JSON) with
+  remediation hints instead of argparse's default ``prog: error:`` line.
+* Handlers raise :class:`ZehutError`; :func:`_dispatch` catches and emits.
+* Unknown exceptions are wrapped as ``EXIT_INTERNAL`` so no Python
+  traceback ever reaches the user.
+* Noun groups (``user``, ``configuration``) register themselves via a
+  ``register(subparsers)`` function — wired in later tasks.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 
 from zehut import __version__
+from zehut.cli._errors import (
+    EXIT_INTERNAL,
+    EXIT_USER_ERROR,
+    ZehutError,
+)
+from zehut.cli._output import emit_error
+
+
+class _ZehutArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that routes errors through :func:`emit_error`.
+
+    Argparse's default ``error()`` writes ``prog: error: <msg>`` and exits.
+    That skips our ZehutError plumbing (no hint, wrong exit code). This
+    subclass emits the structured format and exits with
+    ``EXIT_USER_ERROR``.
+
+    JSON mode: parse-time errors happen before ``args.json`` exists, so we
+    rely on ``_json_hint`` that :func:`main` pre-populates by peeking at
+    argv for ``--json`` / ``--json=…``.
+    """
+
+    _json_hint: bool = False
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        err = ZehutError(
+            code=EXIT_USER_ERROR,
+            message=message,
+            remediation=f"run '{self.prog} --help' to see valid arguments",
+        )
+        emit_error(err, json_mode=type(self)._json_hint)
+        raise SystemExit(err.code)
+
+
+def _argv_has_json(argv: list[str] | None) -> bool:
+    tokens = argv if argv is not None else sys.argv[1:]
+    return any(t == "--json" or t.startswith("--json=") for t in tokens)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = _ZehutArgumentParser(
+        prog="zehut",
+        description="zehut — agents-first identity layer",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit structured JSON for results and errors.",
+    )
+    # parser_class propagates to every subparser so .error() routes through
+    # _ZehutArgumentParser everywhere.
+    parser.add_subparsers(dest="command", parser_class=_ZehutArgumentParser)
+    # Noun groups register here in later tasks (user, configuration),
+    # along with globals (init, doctor, learn, overview, explain).
+    return parser
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    """Invoke the registered handler; translate exceptions to exit codes."""
+    json_mode = bool(getattr(args, "json", False))
+    func = getattr(args, "func", None)
+    if func is None:
+        # No subcommand selected — caller should have printed help.
+        return 0
+    try:
+        rc = func(args)
+    except ZehutError as err:
+        emit_error(err, json_mode=json_mode)
+        return err.code
+    except SystemExit:  # pragma: no cover — let argparse exits propagate
+        raise
+    except Exception as err:  # noqa: BLE001 — last-resort wrap
+        wrapped = ZehutError(
+            code=EXIT_INTERNAL,
+            message=f"unexpected: {err.__class__.__name__}: {err}",
+            remediation="file a bug at https://github.com/OriNachum/zehut/issues",
+        )
+        emit_error(wrapped, json_mode=json_mode)
+        return wrapped.code
+    return rc if rc is not None else 0
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = argv if argv is not None else sys.argv[1:]
-    if args == ["--version"]:
-        print(f"zehut {__version__}")
+    _ZehutArgumentParser._json_hint = _argv_has_json(argv)
+    parser = _build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # argparse raises SystemExit for --version, --help, and parse errors
+        # (our _ZehutArgumentParser.error() also raises SystemExit).
+        # Convert to an integer return code so callers get a clean int back.
+        return int(exc.code) if exc.code is not None else 0
+    if getattr(args, "command", None) is None:
+        parser.print_help()
         return 0
-    # Placeholder: anything else prints a stub message.
-    # NOTE: Task 6 replaces this with argparse dispatch; unknown verbs
-    # will then return EXIT_USER_ERROR (64).
-    print("zehut CLI not yet implemented — see docs/superpowers/plans/", file=sys.stderr)
-    return 0
+    return _dispatch(args)
 
 
 if __name__ == "__main__":

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -93,6 +93,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
     _doctor_cmd.register(sub)
 
+    from zehut.cli._commands import explain as _explain_cmd  # noqa: WPS433
+    from zehut.cli._commands import learn as _learn_cmd  # noqa: WPS433
+    from zehut.cli._commands import overview as _overview_cmd  # noqa: WPS433
+
+    _learn_cmd.register(sub)
+    _overview_cmd.register(sub)
+    _explain_cmd.register(sub)
+
     # More noun groups and globals register here in later tasks.
     return parser
 

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -81,6 +81,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     _init_cmd.register(sub)
 
+    from zehut.cli._commands import configuration as _configuration_cmd  # noqa: WPS433
+
+    _configuration_cmd.register(sub)
+
     # More noun groups and globals register here in later tasks.
     return parser
 

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -17,7 +17,8 @@ def main(argv: list[str] | None = None) -> int:
         print(f"zehut {__version__}")
         return 0
     # Placeholder: anything else prints a stub message.
-    # NOTE: Task 6 replaces this with argparse dispatch; unknown verbs will return EXIT_USER_ERROR (64).
+    # NOTE: Task 6 replaces this with argparse dispatch; unknown verbs
+    # will then return EXIT_USER_ERROR (64).
     print("zehut CLI not yet implemented — see docs/superpowers/plans/", file=sys.stderr)
     return 0
 

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -26,13 +26,30 @@ from zehut.cli._errors import (
 from zehut.cli._output import emit_error
 
 
+class _ParserExit(Exception):
+    """Internal signal that argparse wants the program to exit.
+
+    Raised from :meth:`_ZehutArgumentParser.exit` and ``.error`` instead of
+    ``SystemExit``. :func:`main` catches this and converts to an integer
+    return code. Keeping SystemExit out of zehut code means Sonar's S5754
+    ("reraise SystemExit") never has reason to flag us — the rule only
+    fires on SystemExit catches that don't reraise.
+    """
+
+    def __init__(self, code: int) -> None:
+        super().__init__(f"_ParserExit({code})")
+        self.code = code
+
+
 class _ZehutArgumentParser(argparse.ArgumentParser):
     """ArgumentParser that routes errors through :func:`emit_error`.
 
     Argparse's default ``error()`` writes ``prog: error: <msg>`` and exits.
     That skips our ZehutError plumbing (no hint, wrong exit code). This
-    subclass emits the structured format and exits with
-    ``EXIT_USER_ERROR``.
+    subclass emits the structured format and raises :class:`_ParserExit`
+    instead of ``SystemExit``. The overridden ``exit()`` intercepts the
+    same calls argparse makes from ``_VersionAction`` and ``_HelpAction``
+    so those paths also surface as ``_ParserExit``.
 
     JSON mode: parse-time errors happen before ``args.json`` exists, so we
     rely on ``_json_hint`` that :func:`main` pre-populates by peeking at
@@ -48,7 +65,15 @@ class _ZehutArgumentParser(argparse.ArgumentParser):
             remediation=f"run '{self.prog} --help' to see valid arguments",
         )
         emit_error(err, json_mode=type(self)._json_hint)
-        raise SystemExit(err.code)
+        raise _ParserExit(err.code)
+
+    def exit(self, status: int = 0, message: str | None = None) -> None:  # type: ignore[override]
+        # argparse invokes this from _VersionAction, _HelpAction, and from
+        # its own error path (.error() → parser.exit()). Raising
+        # _ParserExit keeps SystemExit out of our codebase.
+        if message:
+            self._print_message(message, sys.stderr)
+        raise _ParserExit(int(status))
 
 
 def _argv_has_json(argv: list[str] | None) -> bool:
@@ -117,8 +142,6 @@ def _dispatch(args: argparse.Namespace) -> int:
     except ZehutError as err:
         emit_error(err, json_mode=json_mode)
         return err.code
-    except SystemExit:  # pragma: no cover — let argparse exits propagate
-        raise
     except Exception as err:  # noqa: BLE001 — last-resort wrap
         wrapped = ZehutError(
             code=EXIT_INTERNAL,
@@ -135,18 +158,15 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     try:
         args = parser.parse_args(argv)
-    except SystemExit as exc:
-        # argparse raises SystemExit for --version, --help, and parse errors
-        # (our _ZehutArgumentParser.error() also raises SystemExit).
-        # Convert to an integer return code so callers get a clean int back.
-        return int(exc.code) if exc.code is not None else 0
+    except _ParserExit as exc:
+        # argparse's --version, --help, and parse-error paths now raise
+        # _ParserExit (see _ZehutArgumentParser). Convert to int so callers
+        # receive a clean return code.
+        return exc.code
     if getattr(args, "command", None) is None:
         parser.print_help()
         return 0
-    try:
-        return _dispatch(args)
-    except SystemExit as exc:
-        return int(exc.code) if exc.code is not None else 0
+    return _dispatch(args)
 
 
 if __name__ == "__main__":

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -131,7 +131,10 @@ def main(argv: list[str] | None = None) -> int:
     if getattr(args, "command", None) is None:
         parser.print_help()
         return 0
-    return _dispatch(args)
+    try:
+        return _dispatch(args)
+    except SystemExit as exc:
+        return int(exc.code) if exc.code is not None else 0
 
 
 if __name__ == "__main__":

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -85,6 +85,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     _configuration_cmd.register(sub)
 
+    from zehut.cli._commands import user as _user_cmd  # noqa: WPS433
+
+    _user_cmd.register(sub)
+
     # More noun groups and globals register here in later tasks.
     return parser
 

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -1,0 +1,26 @@
+"""CLI entry point — Task 1 placeholder.
+
+This module is fleshed out in Task 6 (parser + dispatch + error routing).
+For now it exists so ``uv run zehut --version`` and ``python -m zehut`` work.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from zehut import __version__
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if args == ["--version"]:
+        print(f"zehut {__version__}")
+        return 0
+    # Placeholder: anything else prints a stub message.
+    # NOTE: Task 6 replaces this with argparse dispatch; unknown verbs will return EXIT_USER_ERROR (64).
+    print("zehut CLI not yet implemented — see docs/superpowers/plans/", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/zehut/cli/__init__.py
+++ b/zehut/cli/__init__.py
@@ -89,6 +89,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     _user_cmd.register(sub)
 
+    from zehut.cli._commands import doctor as _doctor_cmd  # noqa: WPS433
+
+    _doctor_cmd.register(sub)
+
     # More noun groups and globals register here in later tasks.
     return parser
 

--- a/zehut/cli/_commands/configuration.py
+++ b/zehut/cli/_commands/configuration.py
@@ -1,0 +1,90 @@
+"""``zehut configuration`` — show and mutate ``/etc/zehut/config.toml``.
+
+Verbs:
+
+* ``show``          — render current config (text or JSON).
+* ``set``           — set a named key; delegates to :func:`zehut.config.set_key`.
+* ``set-domain``    — convenience shortcut for the most common mutation.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+
+from zehut import config, privilege
+from zehut.cli._errors import EXIT_PRIVILEGE, EXIT_STATE, ZehutError
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("configuration", help="Show or modify zehut configuration.")
+    sub = p.add_subparsers(dest="verb", required=True)
+
+    s_show = sub.add_parser("show", help="Render the current configuration.")
+    s_show.set_defaults(func=_cmd_show)
+
+    s_set = sub.add_parser("set", help="Set a configuration key.")
+    s_set.add_argument("key")
+    s_set.add_argument("value")
+    s_set.set_defaults(func=_cmd_set)
+
+    s_sd = sub.add_parser("set-domain", help="Shortcut for 'configuration set domain <value>'.")
+    s_sd.add_argument("domain")
+    s_sd.set_defaults(func=_cmd_set_domain)
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        cfg = config.load()
+    except config.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    payload = asdict(cfg)
+    if json_mode:
+        emit_result(payload, json_mode=True)
+    else:
+        lines = [
+            f"schema_version: {payload['schema_version']}",
+            f"domain:          {payload['domain']}",
+            f"default_backend: {payload['default_backend']}",
+            f"email_pattern:   {payload['email_pattern']}",
+            f"email_collision: {payload['email_collision']}",
+        ]
+        emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+def _require_root(argv: list[str]) -> None:
+    try:
+        privilege.require_root(action="modify /etc/zehut/config.toml", argv=argv)
+    except privilege.PrivilegeError as err:
+        raise ZehutError(
+            code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+        ) from err
+
+
+def _cmd_set(args: argparse.Namespace) -> int:
+    _require_root(["configuration", "set", args.key, args.value])
+    try:
+        config.set_key(args.key, args.value)
+    except config.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE, message=str(err), remediation="zehut configuration show"
+        ) from err
+    return _cmd_show(args)
+
+
+def _cmd_set_domain(args: argparse.Namespace) -> int:
+    _require_root(["configuration", "set-domain", args.domain])
+    try:
+        config.set_key("domain", args.domain)
+    except config.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE, message=str(err), remediation="zehut configuration show"
+        ) from err
+    return _cmd_show(args)

--- a/zehut/cli/_commands/doctor.py
+++ b/zehut/cli/_commands/doctor.py
@@ -67,17 +67,22 @@ def _check_file_modes() -> Check:
     for p in (cfg_path, users_path):
         if not p.exists():
             continue
-        mode = p.stat().st_mode & 0o777
+        st = p.stat()
+        mode = st.st_mode & 0o777
         if mode != 0o644:
             problems.append(f"{p} mode={oct(mode)} (expected 0o644)")
+        if st.st_uid != 0:
+            problems.append(f"{p} uid={st.st_uid} (expected 0/root)")
+        if st.st_gid != 0:
+            problems.append(f"{p} gid={st.st_gid} (expected 0/root)")
     if problems:
         return Check(
             "file_modes",
             "WARN",
             "; ".join(problems),
-            "fix with: sudo chmod 644 <path>",
+            "fix with: sudo chmod 644 <path> and sudo chown root:root <path>",
         )
-    return Check("file_modes", "PASS", "0o644", "")
+    return Check("file_modes", "PASS", "0o644 root:root", "")
 
 
 def _check_useradd_on_path() -> Check:

--- a/zehut/cli/_commands/doctor.py
+++ b/zehut/cli/_commands/doctor.py
@@ -210,7 +210,9 @@ _CHECKS = (
 )
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace) -> None:
+    # Returns None — _dispatch converts that to EXIT_SUCCESS. doctor is a
+    # report, not a gate, so it never signals failure via exit code.
     json_mode = bool(getattr(args, "json", False))
     results = [c() for c in _CHECKS]
     if json_mode:
@@ -228,7 +230,7 @@ def run(args: argparse.Namespace) -> int:
             },
             json_mode=True,
         )
-        return 0
+        return
 
     lines = []
     for r in results:
@@ -238,4 +240,3 @@ def run(args: argparse.Namespace) -> int:
         if r.remediation:
             lines.append(f"    hint: {r.remediation}")
     emit_result("\n".join(lines), json_mode=False)
-    return 0

--- a/zehut/cli/_commands/doctor.py
+++ b/zehut/cli/_commands/doctor.py
@@ -1,0 +1,233 @@
+"""``zehut doctor`` — read-only system health report.
+
+Eight checks from spec §6.3. Each check returns a dict with ``name``,
+``status`` (``PASS`` | ``FAIL`` | ``WARN``), ``detail``, and
+``remediation``. The command itself always exits 0: it's a report, not a
+gate. Callers who want a non-zero exit on any FAIL should inspect the
+JSON output (``--json``) and react accordingly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pwd
+import re
+import shutil
+from dataclasses import dataclass
+
+from zehut import config as cfg_mod
+from zehut import fs, users
+from zehut.cli._output import emit_result
+
+_DOMAIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    detail: str
+    remediation: str
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("doctor", help="Read-only health check.")
+    p.set_defaults(func=run)
+
+
+def _check_config_exists() -> Check:
+    path = fs.config_file()
+    if path.exists():
+        return Check("config_exists", "PASS", str(path), "")
+    return Check(
+        "config_exists",
+        "FAIL",
+        f"{path} missing",
+        "run: sudo zehut init --domain <d> --default-backend <backend>",
+    )
+
+
+def _check_users_exists() -> Check:
+    path = fs.users_file()
+    if path.exists():
+        return Check("users_exists", "PASS", str(path), "")
+    return Check(
+        "users_exists",
+        "FAIL",
+        f"{path} missing",
+        "run: sudo zehut init ... (or 'zehut init --force' to rebuild)",
+    )
+
+
+def _check_file_modes() -> Check:
+    cfg_path = fs.config_file()
+    users_path = fs.users_file()
+    problems: list[str] = []
+    for p in (cfg_path, users_path):
+        if not p.exists():
+            continue
+        mode = p.stat().st_mode & 0o777
+        if mode != 0o644:
+            problems.append(f"{p} mode={oct(mode)} (expected 0o644)")
+    if problems:
+        return Check(
+            "file_modes",
+            "WARN",
+            "; ".join(problems),
+            "fix with: sudo chmod 644 <path>",
+        )
+    return Check("file_modes", "PASS", "0o644", "")
+
+
+def _check_useradd_on_path() -> Check:
+    # Only relevant if any system-backed users exist.
+    try:
+        has_system = any(r.backend == "system" for r in users.list_all())
+    except Exception:
+        has_system = False
+    if not has_system:
+        return Check("useradd_available", "PASS", "not required", "")
+    for binary in ("useradd", "userdel", "id"):
+        if shutil.which(binary) is None:
+            return Check(
+                "useradd_available",
+                "FAIL",
+                f"{binary} not on PATH",
+                "install the 'shadow' / 'shadow-utils' package for your distro",
+            )
+    return Check("useradd_available", "PASS", "useradd, userdel, id on PATH", "")
+
+
+def _check_system_users_resolve() -> Check:
+    try:
+        recs = users.list_all()
+    except Exception as err:
+        return Check("system_users_resolve", "FAIL", str(err), "inspect /var/lib/zehut/users.json")
+    problems: list[str] = []
+    for rec in recs:
+        if rec.backend != "system":
+            continue
+        target = rec.system_user or rec.name
+        try:
+            entry = pwd.getpwnam(target)
+        except KeyError:
+            problems.append(f"{rec.name}: OS user {target!r} missing")
+            continue
+        if entry.pw_uid != rec.system_uid:
+            problems.append(f"{rec.name}: uid drift (registry={rec.system_uid}, os={entry.pw_uid})")
+    if problems:
+        return Check(
+            "system_users_resolve",
+            "FAIL",
+            "; ".join(problems),
+            "reconcile manually in v1; 'zehut doctor --adopt' is v2",
+        )
+    return Check("system_users_resolve", "PASS", f"{len(recs)} users consistent", "")
+
+
+def _check_logical_name_vs_os() -> Check:
+    try:
+        recs = users.list_all()
+    except Exception:
+        return Check("logical_names_free", "PASS", "registry unreadable; skipped", "")
+    collisions: list[str] = []
+    for rec in recs:
+        if rec.backend != "logical":
+            continue
+        try:
+            pwd.getpwnam(rec.name)
+            collisions.append(rec.name)
+        except KeyError:
+            continue
+    if collisions:
+        return Check(
+            "logical_names_free",
+            "WARN",
+            f"logical names also exist as OS users: {collisions}",
+            "rename (v2) or delete the colliding logical user",
+        )
+    return Check("logical_names_free", "PASS", "no collisions", "")
+
+
+def _check_ambient_resolution() -> Check:
+    try:
+        os_name = pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        return Check("ambient_resolution", "PASS", "no OS user for euid", "")
+    try:
+        recs = users.list_all()
+    except Exception:
+        return Check("ambient_resolution", "PASS", "registry unreadable; skipped", "")
+    for rec in recs:
+        if rec.backend == "system" and rec.system_user == os_name:
+            return Check(
+                "ambient_resolution",
+                "PASS",
+                f"current OS user {os_name!r} resolves to zehut {rec.name!r}",
+                "",
+            )
+    return Check(
+        "ambient_resolution",
+        "PASS",
+        f"current OS user {os_name!r} is not zehut-managed",
+        "",
+    )
+
+
+def _check_domain_format() -> Check:
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        return Check("domain_format", "FAIL", str(err), "run: sudo zehut init ...")
+    if _DOMAIN_RE.match(cfg.domain):
+        return Check("domain_format", "PASS", cfg.domain, "")
+    return Check(
+        "domain_format",
+        "FAIL",
+        f"{cfg.domain!r} not a valid-looking domain",
+        "fix with: sudo zehut configuration set-domain <domain>",
+    )
+
+
+_CHECKS = (
+    _check_config_exists,
+    _check_users_exists,
+    _check_file_modes,
+    _check_useradd_on_path,
+    _check_system_users_resolve,
+    _check_logical_name_vs_os,
+    _check_ambient_resolution,
+    _check_domain_format,
+)
+
+
+def run(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    results = [c() for c in _CHECKS]
+    if json_mode:
+        emit_result(
+            {
+                "checks": [
+                    {
+                        "name": r.name,
+                        "status": r.status,
+                        "detail": r.detail,
+                        "remediation": r.remediation,
+                    }
+                    for r in results
+                ]
+            },
+            json_mode=True,
+        )
+        return 0
+
+    lines = []
+    for r in results:
+        marker = {"PASS": "+", "WARN": "!", "FAIL": "x"}.get(r.status, "?")  # noqa: S105
+        line = f"{marker} [{r.status}] {r.name}: {r.detail}"
+        lines.append(line)
+        if r.remediation:
+            lines.append(f"    hint: {r.remediation}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0

--- a/zehut/cli/_commands/doctor.py
+++ b/zehut/cli/_commands/doctor.py
@@ -21,6 +21,9 @@ from zehut import fs, users
 from zehut.cli._output import emit_result
 
 _DOMAIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# Single-char status markers. Hoisted to module scope so the inline marker
+# lookup doesn't trip bandit's hardcoded-string heuristic (B105/S105).
+_STATUS_MARKERS = {"PASS": "+", "WARN": "!", "FAIL": "x"}  # noqa: S105 # nosec B105
 
 
 @dataclass
@@ -229,7 +232,7 @@ def run(args: argparse.Namespace) -> int:
 
     lines = []
     for r in results:
-        marker = {"PASS": "+", "WARN": "!", "FAIL": "x"}.get(r.status, "?")  # noqa: S105
+        marker = _STATUS_MARKERS.get(r.status, "?")
         line = f"{marker} [{r.status}] {r.name}: {r.detail}"
         lines.append(line)
         if r.remediation:

--- a/zehut/cli/_commands/explain.py
+++ b/zehut/cli/_commands/explain.py
@@ -1,0 +1,71 @@
+"""``zehut explain <topic>`` — prose explanation of a command or concept."""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut.cli._errors import EXIT_USER_ERROR, ZehutError
+from zehut.cli._output import emit_result
+
+_TOPICS: dict[str, str] = {
+    "zehut": (
+        "zehut is the agents-first identity layer. It manages machine-local users "
+        "(system-backed via useradd, or logical/metadata-only) and assigns each one "
+        "a deterministic email from a configured domain. Secrets are NOT in this "
+        "package — a separate CLI consumes the users.json registry for that."
+    ),
+    "user": (
+        "A zehut user is an identity with a stable ULID, a human name, optional "
+        "nick/about metadata, an auto-generated email, and a backing: 'system' "
+        "(real OS user) or 'logical' (metadata only)."
+    ),
+    "user create": (
+        "Creates a new user. With --system, zehut runs useradd to provision a real "
+        "OS account (requires sudo). With --logical, it records metadata only. "
+        "Without either flag, uses configuration.default_backend."
+    ),
+    "user switch": (
+        "Switches identity. For system-backed users, execs `sudo -u <user> -i` "
+        "(which replaces your shell). For logical users, prints "
+        "`export ZEHUT_IDENTITY=<name>` — pair with `eval $(zehut user switch <name>)`."
+    ),
+    "user whoami": (
+        "Prints the current ambient identity. Resolved in order: (1) OS user if "
+        "it matches a system-backed zehut user; (2) $ZEHUT_IDENTITY env var for "
+        "logical users; (3) nothing (exits non-zero)."
+    ),
+    "configuration": (
+        "Machine-wide config lives in /etc/zehut/config.toml. Keys: domain (email "
+        "domain), default_backend (system|logical), email_pattern (tokens: "
+        "{name}, {nick}, {id-short}, fallback syntax {nick|name}), "
+        "email_collision (suffix)."
+    ),
+    "doctor": (
+        "Read-only health report. Eight checks: config exists, registry exists, "
+        "file modes, useradd on PATH, system users resolve, logical names free, "
+        "ambient resolution, domain format. Always exits 0 — inspect --json output."
+    ),
+    "init": (
+        "Bootstraps /etc/zehut/config.toml and /var/lib/zehut/users.json. "
+        "Idempotent: safe to re-run. Use --force to overwrite config (never wipes "
+        "a non-empty user registry)."
+    ),
+}
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("explain", help="Explain a zehut command or concept.")
+    p.add_argument("topic", help="e.g. 'user create', 'doctor', 'zehut'")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    key = args.topic.strip()
+    if key not in _TOPICS:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=f"no explanation for {args.topic!r}",
+            remediation=f"known topics: {', '.join(sorted(_TOPICS))}",
+        )
+    emit_result(_TOPICS[key], json_mode=False)
+    return 0

--- a/zehut/cli/_commands/explain.py
+++ b/zehut/cli/_commands/explain.py
@@ -55,16 +55,16 @@ _TOPICS: dict[str, str] = {
 
 def register(subparsers: "argparse._SubParsersAction") -> None:
     p = subparsers.add_parser("explain", help="Explain a zehut command or concept.")
-    p.add_argument("topic", help="e.g. 'user create', 'doctor', 'zehut'")
+    p.add_argument("topic", nargs="+", help="e.g. 'user create', 'doctor', 'zehut'")
     p.set_defaults(func=run)
 
 
 def run(args: argparse.Namespace) -> int:
-    key = args.topic.strip()
+    key = " ".join(args.topic).strip()
     if key not in _TOPICS:
         raise ZehutError(
             code=EXIT_USER_ERROR,
-            message=f"no explanation for {args.topic!r}",
+            message=f"no explanation for {key!r}",
             remediation=f"known topics: {', '.join(sorted(_TOPICS))}",
         )
     emit_result(_TOPICS[key], json_mode=False)

--- a/zehut/cli/_commands/init.py
+++ b/zehut/cli/_commands/init.py
@@ -1,0 +1,94 @@
+"""``zehut init`` — bootstrap config + users registry.
+
+Idempotent by default: if state already exists, re-running without
+``--force`` is a no-op that reports the current configuration. With
+``--force``, the existing ``config.toml`` is rewritten and the registry
+file is (re)created empty only if no users exist; otherwise ``--force``
+still refuses to wipe data.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut import config, fs, privilege, users
+from zehut.cli._errors import EXIT_CONFLICT, EXIT_PRIVILEGE, ZehutError
+from zehut.cli._output import emit_diagnostic, emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("init", help="Bootstrap zehut state on this machine.")
+    p.add_argument("--domain", required=True, help="Email domain, e.g. agents.example.com")
+    p.add_argument(
+        "--default-backend",
+        required=True,
+        choices=("system", "logical"),
+        help="Default backend for 'zehut user create'.",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing config.toml (never deletes users from a non-empty registry).",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        privilege.require_root(
+            action="write /etc/zehut and /var/lib/zehut",
+            argv=["init", "--domain", args.domain, "--default-backend", args.default_backend],
+        )
+    except privilege.PrivilegeError as err:
+        raise ZehutError(
+            code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+        ) from err
+
+    cfg_path = fs.config_file()
+    already = cfg_path.exists()
+    if already and not args.force:
+        emit_diagnostic(f"zehut already initialised at {cfg_path}", json_mode=json_mode)
+        existing = config.load()
+        users.init_registry()  # ensure users.json exists even after partial prior init
+        emit_result(
+            {
+                "initialised": False,
+                "domain": existing.domain,
+                "default_backend": existing.default_backend,
+                "config_path": str(cfg_path),
+                "users_path": str(fs.users_file()),
+            },
+            json_mode=json_mode,
+        )
+        return 0
+
+    if already and args.force:
+        # Guard: never wipe a non-empty registry implicitly.
+        try:
+            current = users.list_all()
+        except ZehutError:
+            current = []
+        if current:
+            raise ZehutError(
+                code=EXIT_CONFLICT,
+                message=(
+                    f"refusing to --force init with {len(current)} existing users in the registry"
+                ),
+                remediation="delete users individually with 'zehut user delete' first",
+            )
+
+    cfg = config.Config.default(domain=args.domain, backend=args.default_backend)
+    config.save(cfg)
+    users.init_registry()
+    emit_result(
+        {
+            "initialised": True,
+            "domain": cfg.domain,
+            "default_backend": cfg.default_backend,
+            "config_path": str(cfg_path),
+            "users_path": str(fs.users_file()),
+        },
+        json_mode=json_mode,
+    )
+    return 0

--- a/zehut/cli/_commands/init.py
+++ b/zehut/cli/_commands/init.py
@@ -33,7 +33,9 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace) -> None:
+    # Returns None on every success path — _dispatch converts that to
+    # EXIT_SUCCESS. Failure paths raise ZehutError with their own code.
     json_mode = bool(getattr(args, "json", False))
     try:
         privilege.require_root(
@@ -70,7 +72,7 @@ def run(args: argparse.Namespace) -> int:
             },
             json_mode=json_mode,
         )
-        return 0
+        return
 
     if already and args.force:
         # Guard: never wipe a non-empty registry implicitly.
@@ -100,4 +102,3 @@ def run(args: argparse.Namespace) -> int:
         },
         json_mode=json_mode,
     )
-    return 0

--- a/zehut/cli/_commands/init.py
+++ b/zehut/cli/_commands/init.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import argparse
 
 from zehut import config, fs, privilege, users
-from zehut.cli._errors import EXIT_CONFLICT, EXIT_PRIVILEGE, ZehutError
+from zehut.cli._errors import EXIT_CONFLICT, EXIT_PRIVILEGE, EXIT_STATE, ZehutError
 from zehut.cli._output import emit_diagnostic, emit_result
 
 
@@ -49,7 +49,16 @@ def run(args: argparse.Namespace) -> int:
     already = cfg_path.exists()
     if already and not args.force:
         emit_diagnostic(f"zehut already initialised at {cfg_path}", json_mode=json_mode)
-        existing = config.load()
+        try:
+            existing = config.load()
+        except config.ConfigStateError as err:
+            # Corrupt/unreadable config in the idempotent branch should
+            # surface as EXIT_STATE with a clear hint, not EXIT_INTERNAL.
+            raise ZehutError(
+                code=EXIT_STATE,
+                message=str(err),
+                remediation="fix the TOML or re-run with: sudo zehut init --force ...",
+            ) from err
         users.init_registry()  # ensure users.json exists even after partial prior init
         emit_result(
             {

--- a/zehut/cli/_commands/learn.py
+++ b/zehut/cli/_commands/learn.py
@@ -1,0 +1,59 @@
+"""``zehut learn`` — emit a single agent-consumable skill markdown doc.
+
+The output is copy-pasteable into an agent's skills directory (or piped
+into one by an SDK). Keep it terse: the agent reads it once, then reads
+``zehut --help`` / ``zehut explain <topic>`` for detail.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut.cli._output import emit_result
+
+_SKILL_BODY = """\
+---
+name: zehut
+description: >
+  Drive the zehut CLI to manage local machine identities
+  (system-backed and logical) and their emails.
+---
+
+# Using zehut
+
+zehut is the identity layer. Every command is ``zehut <noun> <verb>`` or a
+top-level global.
+
+## Core commands
+
+- ``zehut init --domain <d> --default-backend system|logical`` — one-time bootstrap. Needs sudo.
+- ``zehut user create <name> [--system|--logical] [--nick ..] [--about ..]`` — create a user.
+- ``zehut user list [--json]``, ``zehut user show [<name>]`` — read.
+- ``zehut user set [<name>] nick=.. about=..`` — mutate metadata (sudo).
+- ``zehut user switch <name>`` — logical: prints ``export ZEHUT_IDENTITY=…``
+  (use with ``eval``). System: execs ``sudo -u <user> -i``.
+- ``zehut user whoami`` (aliased ``current``) — ambient identity.
+- ``zehut user delete <name> [--keep-home]`` — remove.
+- ``zehut configuration show|set|set-domain`` — config ops (sudo for writes).
+- ``zehut doctor`` — read-only health checks.
+- ``zehut overview`` — machine-readable snapshot.
+- ``zehut explain <topic>`` — prose explanation.
+
+## Conventions
+
+- Every command accepts ``--json`` at the top level: ``zehut --json ...``.
+- Errors: stderr ``error: <msg>`` + ``hint: <remediation>``, or a JSON
+  object ``{"error", "code", "hint"}`` in ``--json`` mode.
+- Ambient identity: if your process runs under a zehut-created OS user,
+  ``user show`` / ``user set`` default to that user with no arg.
+"""
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("learn", help="Emit an agent-consumable skill document.")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    emit_result(_SKILL_BODY, json_mode=False)
+    return 0

--- a/zehut/cli/_commands/overview.py
+++ b/zehut/cli/_commands/overview.py
@@ -1,0 +1,50 @@
+"""``zehut overview`` — full state snapshot (config + users)."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+
+from zehut import config as cfg_mod
+from zehut import users
+from zehut.cli._errors import EXIT_STATE, ZehutError
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("overview", help="Machine-readable snapshot of config + users.")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    recs = users.list_all()
+    payload = {
+        "config": asdict(cfg),
+        "users": [users.record_to_dict(r) for r in recs],
+    }
+    if json_mode:
+        emit_result(payload, json_mode=True)
+        return 0
+    lines = [
+        "CONFIG",
+        f"  domain:          {cfg.domain}",
+        f"  default_backend: {cfg.default_backend}",
+        f"  email_pattern:   {cfg.email_pattern}",
+        "",
+        f"USERS ({len(recs)})",
+    ]
+    for rec in recs:
+        lines.append(
+            f"  - {rec.name} [{rec.backend}] email={rec.email} nick={rec.nick} about={rec.about}"
+        )
+    emit_result("\n".join(lines), json_mode=False)
+    return 0

--- a/zehut/cli/_commands/overview.py
+++ b/zehut/cli/_commands/overview.py
@@ -16,7 +16,11 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     p.set_defaults(func=run)
 
 
-def run(args: argparse.Namespace) -> int:
+def run(args: argparse.Namespace) -> None:
+    # Returns None — _dispatch converts that to EXIT_SUCCESS. Keeping
+    # return-less paths satisfies Sonar python:S3516 ("refactor to not
+    # always return the same value") by ensuring the function has no
+    # value to return at all.
     json_mode = bool(getattr(args, "json", False))
     try:
         cfg = cfg_mod.load()
@@ -33,7 +37,7 @@ def run(args: argparse.Namespace) -> int:
     }
     if json_mode:
         emit_result(payload, json_mode=True)
-        return 0
+        return
     lines = [
         "CONFIG",
         f"  domain:          {cfg.domain}",
@@ -47,4 +51,3 @@ def run(args: argparse.Namespace) -> int:
             f"  - {rec.name} [{rec.backend}] email={rec.email} nick={rec.nick} about={rec.about}"
         )
     emit_result("\n".join(lines), json_mode=False)
-    return 0

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -102,20 +102,20 @@ def _register_list(sub: "argparse._SubParsersAction") -> None:
     s.set_defaults(func=_cmd_list)
 
 
-def _cmd_list(args: argparse.Namespace) -> int:
+def _cmd_list(args: argparse.Namespace) -> None:
+    # Returns None — _dispatch converts that to EXIT_SUCCESS.
     json_mode = bool(getattr(args, "json", False))
     recs = users.list_all()
     if json_mode:
         emit_result([users.record_to_dict(r) for r in recs], json_mode=True)
-        return 0
+        return
     if not recs:
         emit_result("(no users)", json_mode=False)
-        return 0
+        return
     lines = [f"{'NAME':<20} {'BACKEND':<10} EMAIL"]
     for rec in recs:
         lines.append(f"{rec.name:<20} {rec.backend:<10} {rec.email}")
     emit_result("\n".join(lines), json_mode=False)
-    return 0
 
 
 # --- show ---------------------------------------------------------------------

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -264,12 +264,21 @@ def _cmd_switch(args: argparse.Namespace) -> int:
     # System-backed: exec a login shell as the OS user. This replaces the
     # current process on success.
     import os
-    import shutil
 
     target = rec.system_user or rec.name
-    sudo_path = shutil.which("sudo") or "/usr/bin/sudo"
-    # sudo itself is trusted; we resolve the absolute path up front so a
-    # hostile PATH cannot redirect the exec to a shadow binary.
+    # Deterministic trusted path — `shutil.which("sudo")` would honour a
+    # hostile PATH (Qodo flagged this as path-spoofed-exec). We check the
+    # canonical locations in order and fall back if neither exists.
+    for candidate in ("/usr/bin/sudo", "/bin/sudo"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            sudo_path = candidate
+            break
+    else:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message="sudo not found in /usr/bin or /bin",
+            remediation="install sudo (e.g. apt install sudo) and re-run",
+        )
     try:
         os.execv(sudo_path, [sudo_path, "-u", target, "-i"])  # noqa: S606 # nosec B606
     except OSError as err:

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -30,6 +30,8 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     _register_show(sub)
     _register_set(sub)
     _register_delete(sub)
+    _register_switch(sub)
+    _register_whoami(sub)
 
 
 # --- create -------------------------------------------------------------------
@@ -238,4 +240,62 @@ def _cmd_delete(args: argparse.Namespace) -> int:
         backend = LogicalBackend()
     users.remove(args.name, backend=backend, keep_home=args.keep_home)
     emit_result({"deleted": args.name, "backend": rec.backend}, json_mode=json_mode)
+    return 0
+
+
+# --- switch -------------------------------------------------------------------
+
+
+def _register_switch(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser(
+        "switch",
+        help="Switch identity: execs `sudo -u` for system; prints export for logical.",
+    )
+    s.add_argument("name")
+    s.set_defaults(func=_cmd_switch)
+
+
+def _cmd_switch(args: argparse.Namespace) -> int:
+    rec = users.get(args.name)
+    if rec.backend == "logical":
+        # Print an export line for ``eval $(zehut user switch <name>)``.
+        emit_result(f"export ZEHUT_IDENTITY={rec.name}", json_mode=False)
+        return 0
+    # System-backed: exec a login shell as the OS user. This replaces the
+    # current process on success.
+    import os
+
+    target = rec.system_user or rec.name
+    os.execvp("sudo", ["sudo", "-u", target, "-i"])  # noqa: S606,S607
+    # If execvp returns, something broke.
+    raise ZehutError(  # pragma: no cover — execvp only returns on failure
+        code=EXIT_STATE,
+        message="execvp returned unexpectedly",
+        remediation="verify sudo is installed and on PATH",
+    )
+
+
+# --- whoami / current ---------------------------------------------------------
+
+
+def _register_whoami(sub: "argparse._SubParsersAction") -> None:
+    for verb in ("whoami", "current"):
+        s = sub.add_parser(verb, help="Print the ambient zehut identity.")
+        s.set_defaults(func=_cmd_whoami)
+
+
+def _cmd_whoami(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    name = users.ambient_name()
+    if name is None:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message="no current zehut user",
+            remediation="run 'zehut user switch <name>' or 'zehut user create <name>'",
+        )
+    rec = users.get(name)
+    if json_mode:
+        emit_result(users.record_to_dict(rec), json_mode=True)
+    else:
+        emit_result(f"{rec.name} ({rec.backend}, email={rec.email})", json_mode=False)
     return 0

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -1,8 +1,7 @@
-"""``zehut user`` noun group.
+"""``zehut user`` noun group — create, list, show, set, delete, switch, whoami.
 
-Registers the ``user`` parser and its verbs. Each verb lives as a small
-handler function below. More verbs (list/show/set/switch/whoami/delete)
-are added in subsequent tasks.
+switch/whoami are added in Task 14; this file after Task 13 carries the
+five CRUD verbs plus ``create``.
 """
 
 from __future__ import annotations
@@ -13,7 +12,12 @@ from zehut import config as cfg_mod
 from zehut import privilege, users
 from zehut.backend import LogicalBackend, SystemBackend
 from zehut.backend.base import Backend
-from zehut.cli._errors import EXIT_PRIVILEGE, EXIT_STATE, ZehutError
+from zehut.cli._errors import (
+    EXIT_PRIVILEGE,
+    EXIT_STATE,
+    EXIT_USER_ERROR,
+    ZehutError,
+)
 from zehut.cli._output import emit_result
 
 
@@ -22,6 +26,13 @@ def register(subparsers: "argparse._SubParsersAction") -> None:
     sub = p.add_subparsers(dest="verb", required=True)
 
     _register_create(sub)
+    _register_list(sub)
+    _register_show(sub)
+    _register_set(sub)
+    _register_delete(sub)
+
+
+# --- create -------------------------------------------------------------------
 
 
 def _register_create(sub: "argparse._SubParsersAction") -> None:
@@ -78,4 +89,153 @@ def _cmd_create(args: argparse.Namespace) -> int:
         backend=backend,
     )
     emit_result(users.record_to_dict(rec), json_mode=json_mode)
+    return 0
+
+
+# --- list ---------------------------------------------------------------------
+
+
+def _register_list(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("list", help="List zehut users.")
+    s.set_defaults(func=_cmd_list)
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    recs = users.list_all()
+    if json_mode:
+        emit_result([users.record_to_dict(r) for r in recs], json_mode=True)
+        return 0
+    if not recs:
+        emit_result("(no users)", json_mode=False)
+        return 0
+    lines = [f"{'NAME':<20} {'BACKEND':<10} EMAIL"]
+    for rec in recs:
+        lines.append(f"{rec.name:<20} {rec.backend:<10} {rec.email}")
+    emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+# --- show ---------------------------------------------------------------------
+
+
+def _register_show(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("show", help="Show a user's record.")
+    s.add_argument("name", nargs="?", default=None)
+    s.set_defaults(func=_cmd_show)
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    name = args.name or users.ambient_name()
+    if name is None:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message="no user name given and no ambient identity",
+            remediation="pass <name> or switch with 'zehut user switch <name>'",
+        )
+    rec = users.get(name)
+    if json_mode:
+        emit_result(users.record_to_dict(rec), json_mode=True)
+    else:
+        d = users.record_to_dict(rec)
+        lines = [f"{k}: {v}" for k, v in d.items()]
+        emit_result("\n".join(lines), json_mode=False)
+    return 0
+
+
+# --- set ----------------------------------------------------------------------
+
+
+def _register_set(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("set", help="Mutate user metadata (nick, about).")
+    s.add_argument("name", nargs="?", default=None)
+    s.add_argument("assignments", nargs="+", help="key=value (repeatable)")
+    s.set_defaults(func=_cmd_set)
+
+
+def _parse_assignment(token: str) -> tuple[str, str]:
+    if "=" not in token:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=f"expected key=value, got {token!r}",
+            remediation="use the form 'nick=Ali'",
+        )
+    key, _, value = token.partition("=")
+    if not key:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=f"empty key in assignment {token!r}",
+            remediation="use the form 'nick=Ali'",
+        )
+    return key, value
+
+
+def _cmd_set(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    # If the first assignment arg looks like a name (no '='), ``name`` was
+    # consumed by argparse's nargs='?'. Otherwise all tokens are assignments
+    # and name comes from ambient.
+    name = args.name if args.name and "=" not in args.name else None
+    tokens: list[str] = list(args.assignments)
+    if args.name and "=" in args.name:
+        # argparse put a 'key=value' in 'name'; shift it back.
+        tokens.insert(0, args.name)
+        name = None
+    if name is None:
+        name = users.ambient_name()
+    if name is None:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message="no user name given and no ambient identity",
+            remediation="pass <name> as the first argument",
+        )
+    try:
+        privilege.require_root(action="modify users.json", argv=["user", "set", name, *tokens])
+    except privilege.PrivilegeError as err:
+        raise ZehutError(
+            code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+        ) from err
+
+    fields: dict[str, str] = {}
+    for tok in tokens:
+        k, v = _parse_assignment(tok)
+        fields[k] = v
+    rec = users.update(name, **fields)
+    emit_result(users.record_to_dict(rec), json_mode=json_mode)
+    return 0
+
+
+# --- delete -------------------------------------------------------------------
+
+
+def _register_delete(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("delete", help="Remove a zehut user.")
+    s.add_argument("name")
+    s.add_argument(
+        "--keep-home",
+        action="store_true",
+        help="Don't pass -r to userdel (system-backed only).",
+    )
+    s.set_defaults(func=_cmd_delete)
+
+
+def _cmd_delete(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    rec = users.get(args.name)
+    if rec.backend == "system":
+        try:
+            privilege.require_root(
+                action="delete a system-backed user",
+                argv=["user", "delete", args.name] + (["--keep-home"] if args.keep_home else []),
+            )
+        except privilege.PrivilegeError as err:
+            raise ZehutError(
+                code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+            ) from err
+        backend = SystemBackend()
+    else:
+        backend = LogicalBackend()
+    users.remove(args.name, backend=backend, keep_home=args.keep_home)
+    emit_result({"deleted": args.name, "backend": rec.backend}, json_mode=json_mode)
     return 0

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -1,0 +1,81 @@
+"""``zehut user`` noun group.
+
+Registers the ``user`` parser and its verbs. Each verb lives as a small
+handler function below. More verbs (list/show/set/switch/whoami/delete)
+are added in subsequent tasks.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from zehut import config as cfg_mod
+from zehut import privilege, users
+from zehut.backend import LogicalBackend, SystemBackend
+from zehut.backend.base import Backend
+from zehut.cli._errors import EXIT_PRIVILEGE, EXIT_STATE, ZehutError
+from zehut.cli._output import emit_result
+
+
+def register(subparsers: "argparse._SubParsersAction") -> None:
+    p = subparsers.add_parser("user", help="Manage zehut users.")
+    sub = p.add_subparsers(dest="verb", required=True)
+
+    _register_create(sub)
+
+
+def _register_create(sub: "argparse._SubParsersAction") -> None:
+    s = sub.add_parser("create", help="Create a new zehut user.")
+    s.add_argument("name")
+    bg = s.add_mutually_exclusive_group()
+    bg.add_argument("--system", dest="backend_choice", action="store_const", const="system")
+    bg.add_argument("--logical", dest="backend_choice", action="store_const", const="logical")
+    s.add_argument("--nick", default=None)
+    s.add_argument("--about", default=None)
+    s.set_defaults(func=_cmd_create)
+
+
+def _resolve_backend(choice: str | None) -> tuple[str, Backend]:
+    try:
+        cfg = cfg_mod.load()
+    except cfg_mod.ConfigStateError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=str(err),
+            remediation="run: sudo zehut init --domain <d> --default-backend <backend>",
+        ) from err
+    backend_name = choice or cfg.default_backend
+    if backend_name == "system":
+        return "system", SystemBackend()
+    if backend_name == "logical":
+        return "logical", LogicalBackend()
+    raise ZehutError(
+        code=EXIT_STATE,
+        message=f"invalid backend {backend_name!r}",
+        remediation="configuration.default_backend must be 'system' or 'logical'",
+    )
+
+
+def _cmd_create(args: argparse.Namespace) -> int:
+    json_mode = bool(getattr(args, "json", False))
+    backend_name, backend = _resolve_backend(args.backend_choice)
+    if backend_name == "system":
+        try:
+            privilege.require_root(
+                action="create a system-backed user",
+                argv=["user", "create", args.name, "--system"],
+            )
+        except privilege.PrivilegeError as err:
+            raise ZehutError(
+                code=EXIT_PRIVILEGE, message=err.message, remediation=err.remediation
+            ) from err
+
+    rec = users.add(
+        name=args.name,
+        nick=args.nick,
+        about=args.about,
+        backend_name=backend_name,
+        backend=backend,
+    )
+    emit_result(users.record_to_dict(rec), json_mode=json_mode)
+    return 0

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -270,9 +270,18 @@ def _cmd_switch(args: argparse.Namespace) -> int:
     sudo_path = shutil.which("sudo") or "/usr/bin/sudo"
     # sudo itself is trusted; we resolve the absolute path up front so a
     # hostile PATH cannot redirect the exec to a shadow binary.
-    os.execv(sudo_path, [sudo_path, "-u", target, "-i"])  # noqa: S606 # nosec B606
-    # If execv returns, something broke.
-    raise ZehutError(  # pragma: no cover — execv only returns on failure
+    try:
+        os.execv(sudo_path, [sudo_path, "-u", target, "-i"])  # noqa: S606 # nosec B606
+    except OSError as err:
+        # sudo missing / not executable / not installed.
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=f"cannot exec sudo ({sudo_path}): {err}",
+            remediation="install sudo (e.g. apt install sudo) and re-run",
+        ) from err
+    # execv only returns on failure; if we get here without OSError, surface
+    # a generic internal error rather than pretending success.
+    raise ZehutError(  # pragma: no cover — belt-and-suspenders
         code=EXIT_STATE,
         message="execv returned unexpectedly",
         remediation="verify sudo is installed and on PATH",

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -270,7 +270,7 @@ def _cmd_switch(args: argparse.Namespace) -> int:
     sudo_path = shutil.which("sudo") or "/usr/bin/sudo"
     # sudo itself is trusted; we resolve the absolute path up front so a
     # hostile PATH cannot redirect the exec to a shadow binary.
-    os.execv(sudo_path, [sudo_path, "-u", target, "-i"])  # noqa: S606
+    os.execv(sudo_path, [sudo_path, "-u", target, "-i"])  # noqa: S606 # nosec B606
     # If execv returns, something broke.
     raise ZehutError(  # pragma: no cover — execv only returns on failure
         code=EXIT_STATE,

--- a/zehut/cli/_commands/user.py
+++ b/zehut/cli/_commands/user.py
@@ -264,13 +264,17 @@ def _cmd_switch(args: argparse.Namespace) -> int:
     # System-backed: exec a login shell as the OS user. This replaces the
     # current process on success.
     import os
+    import shutil
 
     target = rec.system_user or rec.name
-    os.execvp("sudo", ["sudo", "-u", target, "-i"])  # noqa: S606,S607
-    # If execvp returns, something broke.
-    raise ZehutError(  # pragma: no cover — execvp only returns on failure
+    sudo_path = shutil.which("sudo") or "/usr/bin/sudo"
+    # sudo itself is trusted; we resolve the absolute path up front so a
+    # hostile PATH cannot redirect the exec to a shadow binary.
+    os.execv(sudo_path, [sudo_path, "-u", target, "-i"])  # noqa: S606
+    # If execv returns, something broke.
+    raise ZehutError(  # pragma: no cover — execv only returns on failure
         code=EXIT_STATE,
-        message="execvp returned unexpectedly",
+        message="execv returned unexpectedly",
         remediation="verify sudo is installed and on PATH",
     )
 

--- a/zehut/cli/_errors.py
+++ b/zehut/cli/_errors.py
@@ -1,0 +1,29 @@
+"""Structured error type + exit-code constants.
+
+Every CLI handler that fails raises :class:`ZehutError`. ``zehut.cli.main``
+catches it, routes through :mod:`zehut.cli._output`, and exits with the
+embedded code. Python tracebacks never reach the user; unknown exceptions
+are wrapped into ``ZehutError(EXIT_INTERNAL, ...)`` at the top level.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+EXIT_SUCCESS = 0
+EXIT_USER_ERROR = 64
+EXIT_STATE = 65
+EXIT_PRIVILEGE = 66
+EXIT_BACKEND = 67
+EXIT_CONFLICT = 68
+EXIT_INTERNAL = 70
+
+
+@dataclass
+class ZehutError(Exception):
+    code: int
+    message: str
+    remediation: str
+
+    def __str__(self) -> str:
+        return self.message

--- a/zehut/cli/_output.py
+++ b/zehut/cli/_output.py
@@ -1,0 +1,52 @@
+"""stdout/stderr split + JSON switch for all CLI output.
+
+Contract:
+
+* **results** → stdout (``emit_result``). Anything a downstream tool or
+  pipe would want to consume.
+* **diagnostics** → stderr (``emit_diagnostic``). Progress, warnings, side
+  info. Always safe to suppress.
+* **errors** → stderr (``emit_error``). Human form is
+  ``error: <msg>\\nhint: <remediation>``; JSON form is
+  ``{"error": msg, "code": N, "hint": remediation}``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from zehut.cli._errors import ZehutError
+
+
+def emit_result(value: Any, *, json_mode: bool) -> None:
+    if json_mode:
+        sys.stdout.write(json.dumps(value, separators=(",", ":"), default=str))
+        sys.stdout.write("\n")
+    else:
+        if isinstance(value, str):
+            sys.stdout.write(value)
+            if not value.endswith("\n"):
+                sys.stdout.write("\n")
+        else:
+            sys.stdout.write(f"{value}\n")
+
+
+def emit_diagnostic(message: str, *, json_mode: bool) -> None:
+    if json_mode:
+        sys.stderr.write(json.dumps({"diagnostic": message}, separators=(",", ":")))
+        sys.stderr.write("\n")
+    else:
+        sys.stderr.write(f"{message}\n")
+
+
+def emit_error(err: ZehutError, *, json_mode: bool) -> None:
+    if json_mode:
+        payload = {"error": err.message, "code": err.code, "hint": err.remediation}
+        sys.stderr.write(json.dumps(payload, separators=(",", ":")))
+        sys.stderr.write("\n")
+    else:
+        sys.stderr.write(f"error: {err.message}\n")
+        if err.remediation:
+            sys.stderr.write(f"hint: {err.remediation}\n")

--- a/zehut/config.py
+++ b/zehut/config.py
@@ -1,0 +1,141 @@
+"""Configuration file (``/etc/zehut/config.toml``) — load, save, validate.
+
+The on-disk format is stable as ``schema_version = 1``. Parsing uses
+``tomllib`` (stdlib, read-only); writing is hand-rolled because the
+serialiser in ``tomllib`` doesn't exist and pulling in ``tomli-w`` would
+add a runtime dependency for ~30 lines of work.
+
+This module never touches the users registry; that is ``zehut.users``'s
+job. Cross-file consistency checks live in ``zehut.cli._commands.doctor``.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, replace
+from typing import Literal
+
+from zehut import fs
+
+Backend = Literal["system", "logical"]
+CollisionMode = Literal["suffix"]
+
+_SCHEMA_VERSION = 1
+_VALID_BACKENDS: tuple[Backend, ...] = ("system", "logical")
+_VALID_COLLISION: tuple[CollisionMode, ...] = ("suffix",)
+_SETTABLE_KEYS = frozenset({"domain", "default_backend", "email_pattern", "email_collision"})
+
+
+class ConfigStateError(Exception):
+    """Raised for any config problem routable to EXIT_STATE (65)."""
+
+
+@dataclass(frozen=True)
+class Config:
+    schema_version: int
+    domain: str
+    default_backend: Backend
+    email_pattern: str
+    email_collision: CollisionMode
+
+    @classmethod
+    def default(cls, *, domain: str, backend: Backend) -> "Config":
+        if backend not in _VALID_BACKENDS:
+            raise ConfigStateError(f"invalid backend {backend!r}")
+        return cls(
+            schema_version=_SCHEMA_VERSION,
+            domain=domain,
+            default_backend=backend,
+            email_pattern="{name}",
+            email_collision="suffix",
+        )
+
+
+def _serialise(cfg: Config) -> str:
+    return (
+        f"schema_version = {cfg.schema_version}\n"
+        "\n"
+        "[defaults]\n"
+        f'backend = "{cfg.default_backend}"\n'
+        "\n"
+        "[email]\n"
+        f'domain = "{cfg.domain}"\n'
+        f'pattern = "{cfg.email_pattern}"\n'
+        f'collision = "{cfg.email_collision}"\n'
+    )
+
+
+def save(cfg: Config) -> None:
+    fs.atomic_write_text(fs.config_file(), _serialise(cfg), mode=0o644)
+
+
+def load() -> Config:
+    path = fs.config_file()
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as err:
+        raise ConfigStateError(f"zehut is not initialized: {path} is missing") from err
+    try:
+        doc = tomllib.loads(raw.decode("utf-8"))
+    except tomllib.TOMLDecodeError as err:
+        raise ConfigStateError(f"invalid TOML in {path}: {err}") from err
+
+    schema = doc.get("schema_version")
+    if schema != _SCHEMA_VERSION:
+        raise ConfigStateError(
+            f"unsupported schema_version {schema!r} in {path}; expected {_SCHEMA_VERSION}"
+        )
+    defaults = doc.get("defaults", {})
+    email = doc.get("email", {})
+    backend = defaults.get("backend")
+    if backend not in _VALID_BACKENDS:
+        raise ConfigStateError(
+            f"invalid [defaults].backend {backend!r}; expected one of {list(_VALID_BACKENDS)}"
+        )
+    domain = email.get("domain")
+    if not isinstance(domain, str) or not domain:
+        raise ConfigStateError(f"missing or empty [email].domain in {path}")
+    pattern = email.get("pattern", "{name}")
+    collision = email.get("collision", "suffix")
+    if collision not in _VALID_COLLISION:
+        raise ConfigStateError(
+            f"invalid [email].collision {collision!r}; expected one of {list(_VALID_COLLISION)}"
+        )
+    return Config(
+        schema_version=_SCHEMA_VERSION,
+        domain=domain,
+        default_backend=backend,
+        email_pattern=pattern,
+        email_collision=collision,
+    )
+
+
+def set_key(key: str, value: str) -> None:
+    """Mutate a single top-level config field and persist.
+
+    ``key`` is one of :data:`_SETTABLE_KEYS`. ``value`` is always accepted
+    as a string; type coercion/validation happens inside :func:`load` on
+    the next read.
+    """
+    if key not in _SETTABLE_KEYS:
+        raise ConfigStateError(
+            f"unknown config key {key!r}; settable keys: {sorted(_SETTABLE_KEYS)}"
+        )
+    cfg = load()
+    if key == "domain":
+        updated = replace(cfg, domain=value)
+    elif key == "default_backend":
+        if value not in _VALID_BACKENDS:
+            raise ConfigStateError(
+                f"invalid default_backend {value!r}; expected one of {list(_VALID_BACKENDS)}"
+            )
+        updated = replace(cfg, default_backend=value)  # type: ignore[arg-type]
+    elif key == "email_pattern":
+        updated = replace(cfg, email_pattern=value)
+    else:  # email_collision
+        if value not in _VALID_COLLISION:
+            raise ConfigStateError(
+                f"invalid email_collision {value!r}; expected one of {list(_VALID_COLLISION)}"
+            )
+        updated = replace(cfg, email_collision=value)  # type: ignore[arg-type]
+    save(updated)

--- a/zehut/config.py
+++ b/zehut/config.py
@@ -12,7 +12,7 @@ job. Cross-file consistency checks live in ``zehut.cli._commands.doctor``.
 from __future__ import annotations
 
 import tomllib
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Literal, cast
 
 from zehut import fs
@@ -152,22 +152,36 @@ def set_key(key: str, value: str) -> None:
             f"unknown config key {key!r}; settable keys: {sorted(_SETTABLE_KEYS)}"
         )
     cfg = load()
+    # Start from the current Config values, then overwrite the one being
+    # set. Building a fresh Config explicitly (instead of chaining
+    # ``dataclasses.replace`` across an if/elif) makes the resulting type
+    # unambiguous to Sonar's type-flow (python:S5655) without `cast`.
+    domain = cfg.domain
+    default_backend: Backend = cfg.default_backend
+    email_pattern = cfg.email_pattern
+    email_collision: CollisionMode = cfg.email_collision
     if key == "domain":
-        updated = replace(cfg, domain=value)
+        domain = value
     elif key == "default_backend":
         if value not in _VALID_BACKENDS:
             raise ConfigStateError(
                 f"invalid default_backend {value!r}; expected one of {list(_VALID_BACKENDS)}"
             )
-        # Narrowed by the membership check above — cast so Sonar's type-flow
-        # (python:S5655) and static checkers see the Literal specialisation.
-        updated = replace(cfg, default_backend=cast(Backend, value))
+        default_backend = cast(Backend, value)
     elif key == "email_pattern":
-        updated = replace(cfg, email_pattern=value)
+        email_pattern = value
     else:  # email_collision
         if value not in _VALID_COLLISION:
             raise ConfigStateError(
                 f"invalid email_collision {value!r}; expected one of {list(_VALID_COLLISION)}"
             )
-        updated = replace(cfg, email_collision=cast(CollisionMode, value))
-    save(updated)
+        email_collision = cast(CollisionMode, value)
+    save(
+        Config(
+            schema_version=cfg.schema_version,
+            domain=domain,
+            default_backend=default_backend,
+            email_pattern=email_pattern,
+            email_collision=email_collision,
+        )
+    )

--- a/zehut/config.py
+++ b/zehut/config.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import tomllib
 from dataclasses import dataclass, replace
-from typing import Literal
+from typing import Literal, cast
 
 from zehut import fs
 
@@ -159,7 +159,9 @@ def set_key(key: str, value: str) -> None:
             raise ConfigStateError(
                 f"invalid default_backend {value!r}; expected one of {list(_VALID_BACKENDS)}"
             )
-        updated = replace(cfg, default_backend=value)  # type: ignore[arg-type]
+        # Narrowed by the membership check above — cast so Sonar's type-flow
+        # (python:S5655) and static checkers see the Literal specialisation.
+        updated = replace(cfg, default_backend=cast(Backend, value))
     elif key == "email_pattern":
         updated = replace(cfg, email_pattern=value)
     else:  # email_collision
@@ -167,5 +169,5 @@ def set_key(key: str, value: str) -> None:
             raise ConfigStateError(
                 f"invalid email_collision {value!r}; expected one of {list(_VALID_COLLISION)}"
             )
-        updated = replace(cfg, email_collision=value)  # type: ignore[arg-type]
+        updated = replace(cfg, email_collision=cast(CollisionMode, value))
     save(updated)

--- a/zehut/config.py
+++ b/zehut/config.py
@@ -51,17 +51,47 @@ class Config:
         )
 
 
+_TOML_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\b": "\\b",
+    "\f": "\\f",
+}
+
+
+def _toml_str(value: str) -> str:
+    """Escape ``value`` for emission as a TOML basic string (double-quoted).
+
+    TOML basic strings must escape backslash, double quote, and control
+    characters. Without this, a domain or pattern containing ``"`` or ``\\``
+    would produce invalid TOML and break the next ``load()``.
+    """
+    escaped = value
+    for ch, sub in _TOML_ESCAPES.items():
+        escaped = escaped.replace(ch, sub)
+    # Reject any remaining raw control characters (U+0000..U+001F minus the
+    # ones handled above, plus U+007F). They're technically escapable as
+    # \uXXXX but we have no use case and rejecting is safer.
+    for ch in escaped:
+        if ord(ch) < 0x20 or ord(ch) == 0x7F:
+            raise ConfigStateError(f"value contains unsupported control character U+{ord(ch):04X}")
+    return f'"{escaped}"'
+
+
 def _serialise(cfg: Config) -> str:
     return (
         f"schema_version = {cfg.schema_version}\n"
         "\n"
         "[defaults]\n"
-        f'backend = "{cfg.default_backend}"\n'
+        f"backend = {_toml_str(cfg.default_backend)}\n"
         "\n"
         "[email]\n"
-        f'domain = "{cfg.domain}"\n'
-        f'pattern = "{cfg.email_pattern}"\n'
-        f'collision = "{cfg.email_collision}"\n'
+        f"domain = {_toml_str(cfg.domain)}\n"
+        f"pattern = {_toml_str(cfg.email_pattern)}\n"
+        f"collision = {_toml_str(cfg.email_collision)}\n"
     )
 
 

--- a/zehut/fs.py
+++ b/zehut/fs.py
@@ -1,0 +1,111 @@
+"""Filesystem primitives: path resolution, locking, atomic writes.
+
+Every other module delegates to this one for anything touching disk. The
+env overrides ``ZEHUT_CONFIG_DIR`` and ``ZEHUT_STATE_DIR`` exist for tests
+and are not a user-facing feature (see docs/testing.md).
+
+Locking: ``exclusive_lock`` and ``shared_lock`` are thin ``fcntl.flock``
+context managers over ``/var/lib/zehut/.lock``. Advisory only — nothing
+outside zehut participates — but enough to serialise zehut's own writers
+against readers on a single host.
+
+Atomic writes: write to a temp sibling, fsync, then ``os.replace``. On
+POSIX this is atomic w.r.t. crashes; readers see either the old file or
+the new one, never a half-written blob.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import json
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+_DEFAULT_CONFIG_DIR = Path("/etc/zehut")
+_DEFAULT_STATE_DIR = Path("/var/lib/zehut")
+
+
+def config_dir() -> Path:
+    return Path(os.environ.get("ZEHUT_CONFIG_DIR", str(_DEFAULT_CONFIG_DIR)))
+
+
+def state_dir() -> Path:
+    return Path(os.environ.get("ZEHUT_STATE_DIR", str(_DEFAULT_STATE_DIR)))
+
+
+def config_file() -> Path:
+    return config_dir() / "config.toml"
+
+
+def users_file() -> Path:
+    return state_dir() / "users.json"
+
+
+def lock_file() -> Path:
+    return state_dir() / ".lock"
+
+
+def atomic_write_text(target: Path, data: str, *, mode: int) -> None:
+    """Write ``data`` to ``target`` atomically, creating parents if needed."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, target)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def read_json(target: Path) -> Any:
+    with target.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@contextmanager
+def _locked(path: Path, op: int) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Open O_RDWR so both LOCK_SH and LOCK_EX work on the same fd.
+    flags = os.O_RDWR | os.O_CREAT
+    fd = os.open(str(path), flags, 0o644)
+    try:
+        fcntl.flock(fd, op)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        try:
+            os.close(fd)
+        except OSError as err:
+            if err.errno != errno.EBADF:
+                raise
+
+
+@contextmanager
+def exclusive_lock(path: Path) -> Iterator[None]:
+    """Hold ``LOCK_EX`` on ``path`` for the duration of the context."""
+    with _locked(path, fcntl.LOCK_EX):
+        yield
+
+
+@contextmanager
+def shared_lock(path: Path) -> Iterator[None]:
+    """Hold ``LOCK_SH`` on ``path`` for the duration of the context."""
+    with _locked(path, fcntl.LOCK_SH):
+        yield

--- a/zehut/fs.py
+++ b/zehut/fs.py
@@ -9,6 +9,12 @@ context managers over ``/var/lib/zehut/.lock``. Advisory only — nothing
 outside zehut participates — but enough to serialise zehut's own writers
 against readers on a single host.
 
+Caution: ``exclusive_lock`` and ``shared_lock`` are NOT re-entrant on the same
+thread. Each call opens a fresh fd, and the kernel treats separate open file
+descriptions as independent lock holders — acquiring the same lock path twice
+without releasing between calls will deadlock. Never nest calls on one lock
+path; acquire at the operation boundary.
+
 Atomic writes: write to a temp sibling, fsync, then ``os.replace``. On
 POSIX this is atomic w.r.t. crashes; readers see either the old file or
 the new one, never a half-written blob.
@@ -57,14 +63,24 @@ def atomic_write_text(target: Path, data: str, *, mode: int) -> None:
         suffix=".tmp",
         dir=str(target.parent),
     )
+    # os.fdopen takes ownership of fd on success. If it raises before that,
+    # we must close fd ourselves — otherwise the raw fd leaks.
+    fd_owned = False
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh = os.fdopen(fd, "w", encoding="utf-8")
+        fd_owned = True
+        with fh:
             fh.write(data)
             fh.flush()
             os.fsync(fh.fileno())
         os.chmod(tmp_path, mode)
         os.replace(tmp_path, target)
     except BaseException:
+        if not fd_owned:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         try:
             os.unlink(tmp_path)
         except FileNotFoundError:

--- a/zehut/fs.py
+++ b/zehut/fs.py
@@ -94,11 +94,26 @@ def read_json(target: Path) -> Any:
 
 
 @contextmanager
-def _locked(path: Path, op: int) -> Iterator[None]:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # Open O_RDWR so both LOCK_SH and LOCK_EX work on the same fd.
-    flags = os.O_RDWR | os.O_CREAT
-    fd = os.open(str(path), flags, 0o644)
+def _locked(path: Path, op: int, *, create: bool) -> Iterator[None]:
+    """Flock context — open mode depends on whether we need write access.
+
+    Exclusive writers pass ``create=True`` so the lock file is auto-created
+    (the writer is root and allowed to). Shared readers pass ``create=False``
+    and open ``O_RDONLY`` so non-root readers can take a read lock on a
+    root-owned, 0o644 lock file — `LOCK_SH` does not require the fd to be
+    writable.
+    """
+    if create:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_RDWR | os.O_CREAT
+        fd = os.open(str(path), flags, 0o644)
+    else:
+        # Read path: do NOT mkdir, do NOT create. If the lock file is absent
+        # the registry hasn't been initialised — let the caller's load raise
+        # a proper ZehutError(EXIT_STATE) from FileNotFoundError instead of
+        # us papering over it by creating state directories we can't own.
+        flags = os.O_RDONLY
+        fd = os.open(str(path), flags)
     try:
         fcntl.flock(fd, op)
         try:
@@ -115,13 +130,23 @@ def _locked(path: Path, op: int) -> Iterator[None]:
 
 @contextmanager
 def exclusive_lock(path: Path) -> Iterator[None]:
-    """Hold ``LOCK_EX`` on ``path`` for the duration of the context."""
-    with _locked(path, fcntl.LOCK_EX):
+    """Hold ``LOCK_EX`` on ``path`` for the duration of the context.
+
+    Creates the lock file (and its parent) if missing. Intended for root-run
+    mutating paths; non-root callers will hit EACCES on `/var/lib/zehut`.
+    """
+    with _locked(path, fcntl.LOCK_EX, create=True):
         yield
 
 
 @contextmanager
 def shared_lock(path: Path) -> Iterator[None]:
-    """Hold ``LOCK_SH`` on ``path`` for the duration of the context."""
-    with _locked(path, fcntl.LOCK_SH):
+    """Hold ``LOCK_SH`` on ``path`` for the duration of the context.
+
+    Read-only: opens the lock file ``O_RDONLY`` and does not create state
+    directories. Safe for non-root readers against a root-owned lock file
+    (0o644). Raises ``FileNotFoundError`` if the lock file doesn't exist —
+    callers should translate that into a meaningful EXIT_STATE error.
+    """
+    with _locked(path, fcntl.LOCK_SH, create=False):
         yield

--- a/zehut/privilege.py
+++ b/zehut/privilege.py
@@ -1,0 +1,56 @@
+"""Privilege detection and sudo-advice construction.
+
+Every handler that mutates system state calls :func:`require_root` with a
+short ``action`` string and the raw argv of the offending command. On
+failure this module raises :class:`PrivilegeError` carrying a ready-to-copy
+remediation (``sudo /abs/path/zehut …``) — we resolve the absolute path
+because ``uv tool install`` places the binary in ``~/.local/bin`` which is
+not on root's ``secure_path`` under typical sudoers configs.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class PrivilegeError(Exception):
+    message: str
+    remediation: str
+
+    def __str__(self) -> str:  # pragma: no cover — trivial
+        return self.message
+
+
+def is_root() -> bool:
+    return os.geteuid() == 0
+
+
+def _zehut_binary() -> str | None:
+    """Return the absolute path to the running zehut binary, if known."""
+    # sys.argv[0] is reliable when invoked as an entry-point script.
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0 and os.path.isabs(argv0) and os.path.exists(argv0):
+        return argv0
+    # Fall back to shutil.which.
+    found = shutil.which("zehut")
+    return found if found else None
+
+
+def sudo_command(argv: list[str]) -> str:
+    binary = _zehut_binary() or "zehut"
+    return " ".join(["sudo", binary, *argv])
+
+
+def require_root(*, action: str, argv: list[str] | None = None) -> None:
+    if is_root():
+        return
+    argv = argv or []
+    remediation = f"re-run with: {sudo_command(argv)}"
+    raise PrivilegeError(
+        message=f"root privileges required to {action}",
+        remediation=remediation,
+    )

--- a/zehut/privilege.py
+++ b/zehut/privilege.py
@@ -26,6 +26,11 @@ class PrivilegeError(Exception):
 
 
 def is_root() -> bool:
+    # ZEHUT_ASSUME_ROOT is a test-only hook (see docs/testing.md) — it lets the
+    # self-verify harness exercise privilege-gated commands without running as
+    # real root. Not advertised as a user feature.
+    if os.environ.get("ZEHUT_ASSUME_ROOT") == "1":
+        return True
     return os.geteuid() == 0
 
 

--- a/zehut/privilege.py
+++ b/zehut/privilege.py
@@ -11,6 +11,7 @@ not on root's ``secure_path`` under typical sudoers configs.
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import sys
 from dataclasses import dataclass
@@ -46,8 +47,11 @@ def _zehut_binary() -> str | None:
 
 
 def sudo_command(argv: list[str]) -> str:
+    # shlex.join quotes any element containing whitespace or shell
+    # metacharacters so the printed remediation is safe to paste verbatim
+    # (e.g. --about "QA agent" survives the round-trip).
     binary = _zehut_binary() or "zehut"
-    return " ".join(["sudo", binary, *argv])
+    return shlex.join(["sudo", binary, *argv])
 
 
 def require_root(*, action: str, argv: list[str] | None = None) -> None:

--- a/zehut/users.py
+++ b/zehut/users.py
@@ -39,6 +39,10 @@ from zehut.cli._errors import (
 _SCHEMA_VERSION = 1
 _CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _NAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+# Shared remediation string for "user not found" errors — extracted as a
+# constant so the same hint reads identically from get(), update(), and
+# remove() (Sonar python:S1192).
+_LIST_USERS_HINT = "list users with: zehut user list"
 _EMAIL_DOMAIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _MUTABLE_KEYS = frozenset({"nick", "about"})
 _MAX_EMAIL_SUFFIX = 99
@@ -222,14 +226,14 @@ def get(name: str) -> UserRecord:
     raise ZehutError(
         code=EXIT_USER_ERROR,
         message=f"no such zehut user {name!r}",
-        remediation="list users with: zehut user list",
+        remediation=_LIST_USERS_HINT,
     )
 
 
 def _allocate_email(base_email: str, existing_emails: set[str]) -> str:
     if base_email not in existing_emails:
         return base_email
-    local, at, domain = base_email.partition("@")
+    local, _, domain = base_email.partition("@")
     for n in range(2, _MAX_EMAIL_SUFFIX + 1):
         candidate = f"{local}-{n}@{domain}"
         if candidate not in existing_emails:
@@ -322,7 +326,7 @@ def update(name: str, **fields: Any) -> UserRecord:
     raise ZehutError(
         code=EXIT_USER_ERROR,
         message=f"no such zehut user {name!r}",
-        remediation="list users with: zehut user list",
+        remediation=_LIST_USERS_HINT,
     )
 
 
@@ -338,7 +342,7 @@ def remove(name: str, *, backend: Backend, keep_home: bool) -> None:
             raise ZehutError(
                 code=EXIT_USER_ERROR,
                 message=f"no such zehut user {name!r}",
-                remediation="list users with: zehut user list",
+                remediation=_LIST_USERS_HINT,
             )
         doc["users"] = [e for e in doc["users"] if e["name"] != name]
         _save_raw(doc)
@@ -351,6 +355,33 @@ def remove(name: str, *, backend: Backend, keep_home: bool) -> None:
         )
 
 
+def _current_os_user() -> str | None:
+    """Return the current OS user's login name, or None if unresolvable."""
+    try:
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        return None
+
+
+def _match_system_backed(records: list[UserRecord], os_name: str) -> str | None:
+    """Return the name of the system-backed record whose OS user matches."""
+    for rec in records:
+        # Fall back to rec.name if system_user isn't populated (older
+        # records or manual edits) — matches how _cmd_switch and doctor
+        # treat system_user as optional.
+        if rec.backend == "system" and (rec.system_user or rec.name) == os_name:
+            return rec.name
+    return None
+
+
+def _match_by_name(records: list[UserRecord], name: str) -> str | None:
+    """Return name if a record with that name exists, else None."""
+    for rec in records:
+        if rec.name == name:
+            return rec.name
+    return None
+
+
 def ambient_name() -> str | None:
     """Resolve the ambient identity name, or None.
 
@@ -360,26 +391,16 @@ def ambient_name() -> str | None:
     2. ``$ZEHUT_IDENTITY`` env var if it names an existing record.
     3. ``None``.
     """
-    try:
-        os_name: str | None = pwd.getpwuid(os.geteuid()).pw_name
-    except KeyError:
-        os_name = None
+    os_name = _current_os_user()
     env_name = os.environ.get("ZEHUT_IDENTITY")
     if os_name is None and not env_name:
         return None
     # Single read so both branches see a consistent snapshot.
     records = list_all()
-    if os_name:
-        for rec in records:
-            # Fall back to rec.name if system_user isn't populated (older
-            # records or manual edits) — matches how _cmd_switch and doctor
-            # treat system_user as optional.
-            if rec.backend == "system" and (rec.system_user or rec.name) == os_name:
-                return rec.name
-    if env_name:
-        for rec in records:
-            if rec.name == env_name:
-                return rec.name
+    if os_name and (hit := _match_system_backed(records, os_name)) is not None:
+        return hit
+    if env_name and (hit := _match_by_name(records, env_name)) is not None:
+        return hit
     return None
 
 

--- a/zehut/users.py
+++ b/zehut/users.py
@@ -247,6 +247,14 @@ def add(
                 message=f"zehut user {name!r} already exists",
                 remediation="pick a different name or edit with: zehut user set",
             )
+        # Spec §6.2: refuse to adopt foreign OS users. Checked before
+        # backend.provision so we surface EXIT_CONFLICT (not EXIT_BACKEND).
+        if backend_name == "system" and backend.exists(name):
+            raise ZehutError(
+                code=EXIT_CONFLICT,
+                message=(f"OS user {name!r} exists and is not zehut-managed; refusing to adopt"),
+                remediation="pick a different name; v2 will add 'doctor --adopt'",
+            )
         new_id = _generate_ulid()
         base_email = render_email(
             cfg.email_pattern,

--- a/zehut/users.py
+++ b/zehut/users.py
@@ -1,0 +1,355 @@
+"""User registry — CRUD over ``/var/lib/zehut/users.json``.
+
+Every mutation takes the advisory exclusive lock at ``fs.lock_file()``
+and writes atomically via ``fs.atomic_write_text``. Backend calls happen
+while the lock is held so registry state and OS state cannot diverge due
+to a concurrent race inside zehut.
+
+Transactional ordering (spec §5.5):
+
+* ``add`` with system backend: ``backend.provision`` → registry write.
+  If the write crashes, a later ``zehut doctor`` detects the orphan OS
+  user. (No registry entry ever points at a missing uid.)
+* ``remove`` with system backend: registry write → ``backend.deprovision``.
+  If deprovision crashes, the registry is clean; ``doctor`` detects the
+  orphan OS user.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from zehut import config, fs
+from zehut.backend.base import Backend, ProvisionResult
+from zehut.cli._errors import (
+    EXIT_CONFLICT,
+    EXIT_STATE,
+    EXIT_USER_ERROR,
+    ZehutError,
+)
+
+_SCHEMA_VERSION = 1
+_CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_NAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+_EMAIL_DOMAIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_MUTABLE_KEYS = frozenset({"nick", "about"})
+_MAX_EMAIL_SUFFIX = 99
+
+
+@dataclass(frozen=True)
+class UserRecord:
+    id: str
+    name: str
+    nick: str | None
+    about: str | None
+    email: str
+    backend: str
+    system_user: str | None
+    system_uid: int | None
+    created_at: str
+    updated_at: str
+
+
+# --- ULID ---------------------------------------------------------------------
+
+
+def _generate_ulid() -> str:
+    """Generate a 26-char Crockford-base32 ULID. No external deps."""
+    ts_ms = int(time.time() * 1000) & ((1 << 48) - 1)
+    rand = secrets.randbits(80)
+    combined = (ts_ms << 80) | rand
+    out: list[str] = []
+    for _ in range(26):
+        out.append(_CROCKFORD[combined & 0x1F])
+        combined >>= 5
+    return "".join(reversed(out))
+
+
+# --- email rendering ----------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"\{([^}]+)\}")
+
+
+def render_email(
+    pattern: str,
+    *,
+    name: str,
+    nick: str | None,
+    domain: str,
+    id_short: str = "",
+) -> str:
+    """Render an email local-part from ``pattern`` and join with ``domain``.
+
+    Supports single tokens ``{name}``, ``{nick}``, ``{id-short}`` and the
+    fallback syntax ``{a|b|c}`` — first non-empty source wins.
+    """
+    sources: dict[str, str] = {
+        "name": name or "",
+        "nick": nick or "",
+        "id-short": id_short or "",
+    }
+
+    def _replace(match: "re.Match[str]") -> str:
+        spec = match.group(1)
+        for key in spec.split("|"):
+            key = key.strip()
+            if key in sources and sources[key]:
+                return sources[key]
+        return ""
+
+    local = _TOKEN_RE.sub(_replace, pattern).strip()
+    if not local:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(
+                f"email pattern {pattern!r} produced an empty local-part "
+                f"(name={name!r}, nick={nick!r})"
+            ),
+            remediation="set --nick or change configuration.email_pattern",
+        )
+    if not _EMAIL_DOMAIN_RE.match(domain):
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=f"invalid configured domain {domain!r}",
+            remediation="fix with: sudo zehut configuration set-domain <domain>",
+        )
+    return f"{local}@{domain}"
+
+
+# --- registry load/save -------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _empty_registry() -> dict[str, Any]:
+    return {"schema_version": _SCHEMA_VERSION, "users": []}
+
+
+def init_registry() -> None:
+    """Create an empty registry file if it doesn't already exist."""
+    path = fs.users_file()
+    if path.exists():
+        return
+    import json
+
+    fs.atomic_write_text(path, json.dumps(_empty_registry(), indent=2), mode=0o644)
+
+
+def _load_raw() -> dict[str, Any]:
+    path = fs.users_file()
+    try:
+        doc = fs.read_json(path)
+    except FileNotFoundError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=f"users registry missing at {path}",
+            remediation="run: sudo zehut init",
+        ) from err
+    if doc.get("schema_version") != _SCHEMA_VERSION:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=(
+                f"unsupported users.json schema_version {doc.get('schema_version')!r}; "
+                f"expected {_SCHEMA_VERSION}"
+            ),
+            remediation="zehut migrate is not yet available (v1); re-init is destructive",
+        )
+    return doc
+
+
+def _save_raw(doc: dict[str, Any]) -> None:
+    import json
+
+    fs.atomic_write_text(fs.users_file(), json.dumps(doc, indent=2), mode=0o644)
+
+
+def _to_record(entry: dict[str, Any]) -> UserRecord:
+    return UserRecord(
+        id=entry["id"],
+        name=entry["name"],
+        nick=entry.get("nick"),
+        about=entry.get("about"),
+        email=entry["email"],
+        backend=entry["backend"],
+        system_user=entry.get("system_user"),
+        system_uid=entry.get("system_uid"),
+        created_at=entry["created_at"],
+        updated_at=entry["updated_at"],
+    )
+
+
+# --- public API ---------------------------------------------------------------
+
+
+def list_all() -> list[UserRecord]:
+    doc = _load_raw()
+    return [_to_record(e) for e in doc["users"]]
+
+
+def get(name: str) -> UserRecord:
+    for rec in list_all():
+        if rec.name == name:
+            return rec
+    raise ZehutError(
+        code=EXIT_USER_ERROR,
+        message=f"no such zehut user {name!r}",
+        remediation="list users with: zehut user list",
+    )
+
+
+def _allocate_email(base_email: str, existing_emails: set[str]) -> str:
+    if base_email not in existing_emails:
+        return base_email
+    local, at, domain = base_email.partition("@")
+    for n in range(2, _MAX_EMAIL_SUFFIX + 1):
+        candidate = f"{local}-{n}@{domain}"
+        if candidate not in existing_emails:
+            return candidate
+    raise ZehutError(
+        code=EXIT_CONFLICT,
+        message=f"email {base_email!r} collided beyond suffix limit {_MAX_EMAIL_SUFFIX}",
+        remediation="pass a distinct --nick or change configuration.email_pattern",
+    )
+
+
+def add(
+    *,
+    name: str,
+    nick: str | None,
+    about: str | None,
+    backend_name: str,
+    backend: Backend,
+) -> UserRecord:
+    if not _NAME_RE.match(name):
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(f"invalid user name {name!r}: must match ^[a-z_][a-z0-9_-]{{0,31}}$"),
+            remediation="pick a POSIX-compliant user name",
+        )
+    cfg = config.load()
+    with fs.exclusive_lock(fs.lock_file()):
+        doc = _load_raw()
+        existing_names = {e["name"] for e in doc["users"]}
+        if name in existing_names:
+            raise ZehutError(
+                code=EXIT_CONFLICT,
+                message=f"zehut user {name!r} already exists",
+                remediation="pick a different name or edit with: zehut user set",
+            )
+        new_id = _generate_ulid()
+        base_email = render_email(
+            cfg.email_pattern,
+            name=name,
+            nick=nick,
+            domain=cfg.domain,
+            id_short=new_id[:8],
+        )
+        existing_emails = {e["email"] for e in doc["users"]}
+        email = _allocate_email(base_email, existing_emails)
+
+        provision: ProvisionResult = backend.provision(name=name)
+        now = _now_iso()
+        entry = {
+            "id": new_id,
+            "name": name,
+            "nick": nick,
+            "about": about,
+            "email": email,
+            "backend": backend_name,
+            "system_user": provision.system_user,
+            "system_uid": provision.system_uid,
+            "created_at": now,
+            "updated_at": now,
+        }
+        doc["users"].append(entry)
+        _save_raw(doc)
+    return _to_record(entry)
+
+
+def update(name: str, **fields: Any) -> UserRecord:
+    unknown = set(fields) - _MUTABLE_KEYS
+    if unknown:
+        raise ZehutError(
+            code=EXIT_USER_ERROR,
+            message=(f"cannot modify {sorted(unknown)}; mutable keys: {sorted(_MUTABLE_KEYS)}"),
+            remediation="backend, email, and system_user are immutable in v1",
+        )
+    with fs.exclusive_lock(fs.lock_file()):
+        doc = _load_raw()
+        for entry in doc["users"]:
+            if entry["name"] == name:
+                entry.update({k: v for k, v in fields.items() if k in _MUTABLE_KEYS})
+                entry["updated_at"] = _now_iso()
+                _save_raw(doc)
+                return _to_record(entry)
+    raise ZehutError(
+        code=EXIT_USER_ERROR,
+        message=f"no such zehut user {name!r}",
+        remediation="list users with: zehut user list",
+    )
+
+
+def remove(name: str, *, backend: Backend, keep_home: bool) -> None:
+    with fs.exclusive_lock(fs.lock_file()):
+        doc = _load_raw()
+        target = None
+        for entry in doc["users"]:
+            if entry["name"] == name:
+                target = entry
+                break
+        if target is None:
+            raise ZehutError(
+                code=EXIT_USER_ERROR,
+                message=f"no such zehut user {name!r}",
+                remediation="list users with: zehut user list",
+            )
+        doc["users"] = [e for e in doc["users"] if e["name"] != name]
+        _save_raw(doc)
+        try:
+            backend.deprovision(
+                name=name,
+                system_user=target.get("system_user"),
+                keep_home=keep_home,
+            )
+        except ZehutError:
+            # Registry is already clean; doctor will surface the orphan.
+            raise
+
+
+def ambient_name() -> str | None:
+    """Resolve the ambient identity name, or None.
+
+    Order (matches spec §3.4):
+
+    1. OS user matching a zehut-managed system-backed entry.
+    2. ``$ZEHUT_IDENTITY`` env var if it names an existing record.
+    3. ``None``.
+    """
+    try:
+        import pwd
+
+        os_name = pwd.getpwuid(os.geteuid()).pw_name
+    except KeyError:
+        os_name = None
+    if os_name:
+        for rec in list_all():
+            if rec.backend == "system" and rec.system_user == os_name:
+                return rec.name
+    env_name = os.environ.get("ZEHUT_IDENTITY")
+    if env_name:
+        for rec in list_all():
+            if rec.name == env_name:
+                return rec.name
+    return None
+
+
+def record_to_dict(rec: UserRecord) -> dict[str, Any]:
+    return asdict(rec)

--- a/zehut/users.py
+++ b/zehut/users.py
@@ -136,11 +136,19 @@ def _empty_registry() -> dict[str, Any]:
 
 
 def init_registry() -> None:
-    """Create an empty registry file if it doesn't already exist."""
+    """Create the empty registry file and the lock file if missing.
+
+    The lock file must exist after init so non-root readers can open it
+    ``O_RDONLY`` and take ``LOCK_SH`` without needing to create it (0o644
+    root-owned) — see spec §5.4 and fs.shared_lock docstring.
+    """
     path = fs.users_file()
-    if path.exists():
-        return
-    fs.atomic_write_text(path, json.dumps(_empty_registry(), indent=2), mode=0o644)
+    lock_path = fs.lock_file()
+    if not path.exists():
+        fs.atomic_write_text(path, json.dumps(_empty_registry(), indent=2), mode=0o644)
+    if not lock_path.exists():
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.touch(mode=0o644)
 
 
 def _load_raw_unlocked() -> dict[str, Any]:
@@ -166,8 +174,18 @@ def _load_raw_unlocked() -> dict[str, Any]:
 
 
 def _load_raw() -> dict[str, Any]:
-    with fs.shared_lock(fs.lock_file()):
-        return _load_raw_unlocked()
+    # shared_lock opens the lock file O_RDONLY without creating it. If it is
+    # missing, state hasn't been initialised — translate to EXIT_STATE so the
+    # caller sees a clean "run: sudo zehut init" hint.
+    try:
+        with fs.shared_lock(fs.lock_file()):
+            return _load_raw_unlocked()
+    except FileNotFoundError as err:
+        raise ZehutError(
+            code=EXIT_STATE,
+            message=f"zehut state not initialised: {err.filename or fs.lock_file()} missing",
+            remediation="run: sudo zehut init",
+        ) from err
 
 
 def _save_raw(doc: dict[str, Any]) -> None:
@@ -353,7 +371,10 @@ def ambient_name() -> str | None:
     records = list_all()
     if os_name:
         for rec in records:
-            if rec.backend == "system" and rec.system_user == os_name:
+            # Fall back to rec.name if system_user isn't populated (older
+            # records or manual edits) — matches how _cmd_switch and doctor
+            # treat system_user as optional.
+            if rec.backend == "system" and (rec.system_user or rec.name) == os_name:
                 return rec.name
     if env_name:
         for rec in records:

--- a/zehut/users.py
+++ b/zehut/users.py
@@ -17,7 +17,9 @@ Transactional ordering (spec §5.5):
 
 from __future__ import annotations
 
+import json
 import os
+import pwd
 import re
 import secrets
 import time
@@ -138,12 +140,10 @@ def init_registry() -> None:
     path = fs.users_file()
     if path.exists():
         return
-    import json
-
     fs.atomic_write_text(path, json.dumps(_empty_registry(), indent=2), mode=0o644)
 
 
-def _load_raw() -> dict[str, Any]:
+def _load_raw_unlocked() -> dict[str, Any]:
     path = fs.users_file()
     try:
         doc = fs.read_json(path)
@@ -165,9 +165,12 @@ def _load_raw() -> dict[str, Any]:
     return doc
 
 
-def _save_raw(doc: dict[str, Any]) -> None:
-    import json
+def _load_raw() -> dict[str, Any]:
+    with fs.shared_lock(fs.lock_file()):
+        return _load_raw_unlocked()
 
+
+def _save_raw(doc: dict[str, Any]) -> None:
     fs.atomic_write_text(fs.users_file(), json.dumps(doc, indent=2), mode=0o644)
 
 
@@ -236,7 +239,7 @@ def add(
         )
     cfg = config.load()
     with fs.exclusive_lock(fs.lock_file()):
-        doc = _load_raw()
+        doc = _load_raw_unlocked()
         existing_names = {e["name"] for e in doc["users"]}
         if name in existing_names:
             raise ZehutError(
@@ -283,7 +286,7 @@ def update(name: str, **fields: Any) -> UserRecord:
             remediation="backend, email, and system_user are immutable in v1",
         )
     with fs.exclusive_lock(fs.lock_file()):
-        doc = _load_raw()
+        doc = _load_raw_unlocked()
         for entry in doc["users"]:
             if entry["name"] == name:
                 entry.update({k: v for k, v in fields.items() if k in _MUTABLE_KEYS})
@@ -299,7 +302,7 @@ def update(name: str, **fields: Any) -> UserRecord:
 
 def remove(name: str, *, backend: Backend, keep_home: bool) -> None:
     with fs.exclusive_lock(fs.lock_file()):
-        doc = _load_raw()
+        doc = _load_raw_unlocked()
         target = None
         for entry in doc["users"]:
             if entry["name"] == name:
@@ -313,15 +316,13 @@ def remove(name: str, *, backend: Backend, keep_home: bool) -> None:
             )
         doc["users"] = [e for e in doc["users"] if e["name"] != name]
         _save_raw(doc)
-        try:
-            backend.deprovision(
-                name=name,
-                system_user=target.get("system_user"),
-                keep_home=keep_home,
-            )
-        except ZehutError:
-            # Registry is already clean; doctor will surface the orphan.
-            raise
+        # Registry write is committed. If deprovision raises, the registry
+        # is already clean; zehut doctor will surface the orphan OS user.
+        backend.deprovision(
+            name=name,
+            system_user=target.get("system_user"),
+            keep_home=keep_home,
+        )
 
 
 def ambient_name() -> str | None:
@@ -334,18 +335,20 @@ def ambient_name() -> str | None:
     3. ``None``.
     """
     try:
-        import pwd
-
-        os_name = pwd.getpwuid(os.geteuid()).pw_name
+        os_name: str | None = pwd.getpwuid(os.geteuid()).pw_name
     except KeyError:
         os_name = None
+    env_name = os.environ.get("ZEHUT_IDENTITY")
+    if os_name is None and not env_name:
+        return None
+    # Single read so both branches see a consistent snapshot.
+    records = list_all()
     if os_name:
-        for rec in list_all():
+        for rec in records:
             if rec.backend == "system" and rec.system_user == os_name:
                 return rec.name
-    env_name = os.environ.get("ZEHUT_IDENTITY")
     if env_name:
-        for rec in list_all():
+        for rec in records:
             if rec.name == env_name:
                 return rec.name
     return None


### PR DESCRIPTION
## Summary

First working version of `zehut`: the identity layer of the agents-first
secrets system. Noun-verb CLI (`zehut user`, `zehut configuration`) plus
agent-first globals (`init`, `doctor`, `learn`, `overview`, `explain`).
System-backed identities via `useradd`/`userdel`; logical identities for
metadata-only accounts; ambient OS-user resolution. State on disk:
`/etc/zehut/config.toml` + `/var/lib/zehut/users.json` — stable contract
for a separate secrets CLI. Zero runtime deps.

See the [design spec](docs/superpowers/specs/2026-04-24-zehut-cli-design.md)
and [implementation plan](docs/superpowers/plans/2026-04-24-zehut-cli-v1.md).

## Test plan

- [ ] CI green (lint, unit, integration-in-docker, version-check)
- [ ] TestPyPI wheel installs from `uv tool install --index-url https://test.pypi.org/simple zehut`
- [ ] Manual smoke on a disposable VM:
  - [ ] `sudo zehut init --domain agents.example.com --default-backend system`
  - [ ] `sudo zehut user create alice --nick Ali`
  - [ ] `zehut user switch alice` → `zehut user whoami` → "alice"
  - [ ] `sudo zehut user delete alice`
  - [ ] `zehut doctor` all PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)